### PR TITLE
Display crates.io info in Hover for dependencies in Cargo.toml

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "dependencies": {
-        "request-light": "^0.2.2",
         "vscode-languageclient": "^3.4.2"
     },
     "devDependencies": {
@@ -177,6 +176,11 @@
                     "type": "string",
                     "default": "rls-preview",
                     "description": "Name of the RLS rustup component."
+                },
+                "rust-client.fetchCrateInfo": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Fetch crate description from crates.io to display on Cargo.toml"
                 },
                 "rust.sysroot": {
                     "type": [

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "dependencies": {
+        "request-light": "^0.2.2",
         "vscode-languageclient": "^3.4.2"
     },
     "devDependencies": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -36,6 +36,7 @@ export class RLSConfiguration {
     public readonly updateOnStartup: boolean;
     public readonly channel: string;
     public readonly componentName: string;
+    public readonly fetchCrateInfo: boolean;
     /**
      * Hidden option that can be specified via `"rls.path"` key (e.g. to `/usr/bin/rls`). If
      * specified, RLS will be spawned by executing a file at the given path.
@@ -62,6 +63,7 @@ export class RLSConfiguration {
 
         this.channel = RLSConfiguration.readChannel(this.rustupPath, configuration);
         this.componentName = configuration.get('rust-client.rls-name', 'rls');
+        this.fetchCrateInfo = configuration.get('rust-client.fetchCrateInfo', true);
 
         // Hidden options that are not exposed to the user
         this.rlsPath = configuration.get('rls.path', null);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,13 +15,12 @@ import { startSpinner, stopSpinner } from './spinner';
 import { RLSConfiguration } from './configuration';
 import { activateTaskProvider, deactivateTaskProvider } from './tasks';
 
-
 import * as child_process from 'child_process';
 import * as fs from 'fs';
-import { xhr } from 'request-light';
+import { get_content } from './utils/get_content';
 
 import { commands, ExtensionContext, Hover, IndentAction, languages, TextEditor,
-    TextEditorEdit, window, workspace } from 'vscode';
+    TextEditorEdit, window, workspace, TextDocument, Range } from 'vscode';
 import { LanguageClient, LanguageClientOptions, Location, NotificationType,
     ServerOptions } from 'vscode-languageclient';
 
@@ -29,8 +28,8 @@ import { LanguageClient, LanguageClientOptions, Location, NotificationType,
 // handle possible `rust-client.*` value changes while extension is running
 export const CONFIGURATION = RLSConfiguration.loadFromWorkspace();
 
-
 const USER_AGENT = 'Visual Studio Code';
+const CRATES_API = 'https://crates.io/api/v1/crates/';
 
 function getSysroot(env: Object): string | Error {
     const rustcSysroot = child_process.spawnSync(
@@ -228,23 +227,43 @@ function diagnosticCounter() {
         });
     });
 }
+
+function findDependencyRange(document: TextDocument) {
+    const text = document.getText();
+    const startOffset = text.search(/^\[dependencies\]/gm);
+    const endOffset = text.slice(startOffset + 13).search(/\[|$/);
+    const startPosition = document.positionAt(startOffset);
+    const endPosition = document.positionAt(startOffset + 13 + endOffset);
+    return (startPosition && endPosition) ? new Range(startPosition, endPosition) : undefined;
+}
+
 function registerHovers(context: ExtensionContext) {
-    const crateLookupDisposable = languages.registerHoverProvider({'language': 'toml', 'pattern': '**/Cargo.toml'}, {
-        provideHover(document, position, _token) {
-        const range = document.getWordRangeAtPosition(position,/[a-zA-Z][a-zA-Z0-9-_]*|_[a-zA-Z0-9-_]+/);
-            if (range === undefined || range.start.character != 0) {return undefined;}
-            const crate = document.getText(range); // Poor heuristic: Actually any word that begins a line
-            return xhr({
-                url: 'https://crates.io/api/v1/crates/' + crate,
-                agent: USER_AGENT,
-                responseType: 'json'
-            }).then(response => {
-                const resObj = JSON.parse(response.responseText);
-                return new Hover(`${resObj.crate.description}\n\nLatest version: ${resObj.crate.max_version}`);}
-            ).catch(() => undefined);
-        }
-    });
-    context.subscriptions.push(crateLookupDisposable);
+    if (CONFIGURATION.fetchCrateInfo) {
+        const state: {[idx: string]: string} = {};
+        const crateLookupDisposable = languages.registerHoverProvider({'language': 'toml', 'pattern': '**/Cargo.toml'}, {
+            provideHover(document, position, _token) {
+                const range = document.getWordRangeAtPosition(position,/[a-zA-Z][a-zA-Z0-9-_]*|_[a-zA-Z0-9-_]+/);
+                if (range === undefined || range.start.character != 0) { return undefined; }
+                const dependencyRange = findDependencyRange(document);
+                if ( dependencyRange === undefined || ! dependencyRange.contains(range)) { return undefined; }
+                const crate = document.getText(range); // Poor heuristic: Actually any word that begins a line
+                const crateKey = crate;
+                const crateInfo = state[crateKey];
+                if (crateInfo) {
+                    return new Hover(crateInfo);
+                } else {
+                    return get_content(CRATES_API + crate)
+                    .then((response) => {
+                        const resObj = JSON.parse(response);
+                        const crateInfo = `${resObj.crate.description}\n\nLatest version: ${resObj.crate.max_version}`;
+                        state[crateKey] = crateInfo;
+                        return new Hover(crateInfo);}
+                    ).catch(() => undefined);
+                }
+            }
+        });
+        context.subscriptions.push(crateLookupDisposable);
+    }
 }
 function registerCommands(context: ExtensionContext) {
     const findImplsDisposable = commands.registerTextEditorCommand('rls.findImpls', (textEditor: TextEditor, _edit: TextEditorEdit) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,6 @@ import { LanguageClient, LanguageClientOptions, Location, NotificationType,
 // handle possible `rust-client.*` value changes while extension is running
 export const CONFIGURATION = RLSConfiguration.loadFromWorkspace();
 
-const USER_AGENT = 'Visual Studio Code';
 const CRATES_API = 'https://crates.io/api/v1/crates/';
 
 function getSysroot(env: Object): string | Error {

--- a/src/utils/get_content.ts
+++ b/src/utils/get_content.ts
@@ -1,0 +1,38 @@
+// Copyright 2017 The RLS Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+'use strict';
+
+// Using approach from https://www.tomas-dvorak.cz/posts/nodejs-request-without-dependencies/
+// to avoid dependency
+import { get } from 'https';
+
+
+export function get_content(url: string):Promise<string> {
+    // return new pending promise
+    return new Promise((resolve, reject) => {
+      // select http or https module, depending on reqested url
+      const request = get(url, (response) => {
+        // handle http errors
+        if (response.statusCode && (response.statusCode < 200 || response.statusCode > 299)) {
+           reject(new Error('Failed to load page, status code: ' + response.statusCode));
+         }
+        // temporary data holder
+        const body: Array<string | Buffer> = [];
+        // on every content chunk, push it to the data array
+        response.on('data', (chunk) => body.push(chunk));
+        // we are done, resolve promise with those joined chunks
+        response.on('end', () => resolve(body.join('')));
+      });
+      // handle connection errors of the request
+      request.on('error', (err) => reject(err));
+      });
+  }
+  


### PR DESCRIPTION
Unpolished first attempt at #92:
* As it's my first time touching vscode, I don't know if I'm leaking Request Objects
* I assume crates.io would like some caching
* I don't know if you really want to add a dependency for this (and if so which http client library is acceptable)
* Horribly minimal heuristic to extract crate names: the possible semantics are extensive and I don't want to add real TOML parsing.  I'll see about adding at least a check for [dependencies].
