### PR TITLE
Allow having Cargo.toml in a subdirectory with `rust-client.cargoSubdir`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "dependencies": {
-        "vscode-languageclient": "^4.1.4"
+        "vscode-languageclient": "^4.1.4",
+        "path": "^0.12.0"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.43",
@@ -190,6 +191,11 @@
                     "type": "string",
                     "default": "rls-preview",
                     "description": "Name of the RLS rustup component."
+                },
+                "rust-client.cargoSubdir": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Relative path to Cargo.toml. By default, it is workspace root."
                 },
                 "rust.sysroot": {
                     "type": [

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -40,6 +40,7 @@ export class RLSConfiguration {
      * If specified, RLS will be spawned by executing a file at the given path.
      */
     public readonly rlsPath: string | null;
+    public readonly cargoSubdir: string | null;
 
     public static loadFromWorkspace(): RLSConfiguration {
         const configuration = workspace.getConfiguration();
@@ -66,6 +67,7 @@ export class RLSConfiguration {
         if (!this.rlsPath) {
             this.rlsPath = rlsPath;
         }
+        this.cargoSubdir = configuration.get('rust-client.cargoSubdir', null);
     }
 
     private static readRevealOutputChannelOn(configuration: WorkspaceConfiguration) {


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/rls-vscode/issues/222.

This patch is quite hacky and may reveal my lack of knowledge on the RLS or
LSP architectures. My idea was to give the user the opportunity using the
variable `rust-client.cargoSubdir` to select a subdirectory as the root for
the Cargo.toml file.

To do that, I hacked the vscode's workspaceFoldervariable; my hack won't
work with multi-workspaces.

Alternate solutions:
- (not so good idea) add a new setting to the initialize JSON-RPC (similar
  to the existing `omitInitBuild` in the rls server) that would set a
  different path that the one given by vscode's workspaceFolder.
- (better) we add support for multi-root workspaces in the RLS server;
  (mentionned in  <https://github.com/rust-lang-nursery/rls/issues/608>)
  but this does not really help when we want to open a general project
  where one of the subfolders is a rust project.
- we tell people that in order to get RLS working in a subdirectory, they
  must use the 'Multi-crate projects' feature or the 'rlsCommandOverride'
  feature (see README at <https://github.com/mehcode/atom-ide-rust>).