### PR TITLE
WSL support

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,11 @@
                     "default": "rustup",
                     "description": "Path to rustup executable"
                 },
+                "rust-client.wslPath": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Path to WSL executable"
+                },
                 "rust-client.rlsPath": {
                     "type": [
                         "string",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -31,6 +31,7 @@ function fromStringToRevealOutputChannelOn(value: string): RevealOutputChannelOn
 
 export class RLSConfiguration {
     public readonly rustupPath: string;
+    public readonly wslPath: string | undefined;
     public readonly logToFile: boolean;
     public readonly revealOutputChannelOn: RevealOutputChannelOn = RevealOutputChannelOn.Never;
     public readonly updateOnStartup: boolean;
@@ -49,6 +50,7 @@ export class RLSConfiguration {
 
     private constructor(configuration: WorkspaceConfiguration) {
         this.rustupPath = configuration.get('rust-client.rustupPath', 'rustup');
+        this.wslPath = configuration.get('rust-client.wslPath', undefined);
         this.logToFile = configuration.get<boolean>('rust-client.logToFile', false);
         this.revealOutputChannelOn = RLSConfiguration.readRevealOutputChannelOn(configuration);
         this.updateOnStartup = configuration.get<boolean>('rust-client.updateOnStartup', true);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ import { commands, ExtensionContext, IndentAction, languages, TextEditor,
     TextEditorEdit, window, workspace } from 'vscode';
 import { LanguageClient, LanguageClientOptions, Location, NotificationType,
     ServerOptions } from 'vscode-languageclient';
-import { execFile, ExecChildProcessResult } from './utils/child_process';
+import { ExecChildProcessResult, run_rustup } from './utils/child_process';
 
 // FIXME(#233): Don't only rely on lazily initializing it once on startup,
 // handle possible `rust-client.*` value changes while extension is running
@@ -31,8 +31,8 @@ export const CONFIGURATION = RLSConfiguration.loadFromWorkspace();
 async function getSysroot(env: Object): Promise<string> {
     let output: ExecChildProcessResult;
     try {
-        output = await execFile(
-            CONFIGURATION.rustupPath, ['run', CONFIGURATION.channel, 'rustc', '--print', 'sysroot'], { env }
+        output = await run_rustup(
+            CONFIGURATION.rustupPath, ['run', CONFIGURATION.channel, 'rustc', '--print', 'sysroot'], { env }, CONFIGURATION.wslPath
         );
     } catch (e) {
         throw new Error(`Error getting sysroot from \`rustc\`: ${e}`);

--- a/src/utils/child_process.ts
+++ b/src/utils/child_process.ts
@@ -64,7 +64,7 @@ export async function execFile(command: string, args: string[], options: child_p
 export async function run_rustup(rustup: string, args: string[], options: child_process.ExecFileOptions, wsl?: string): Promise<ExecChildProcessResult> {
     let command: string = rustup;
     if (wsl) {
-        command = wsl
+        command = wsl;
         args.unshift(rustup);
     }
     return execFile(command, args, options);
@@ -73,7 +73,7 @@ export async function run_rustup(rustup: string, args: string[], options: child_
 export function run_rustup_process(rustup: string, args: string[], options: child_process.ExecFileOptions, wsl?: string): child_process.ChildProcess {
     let command: string = rustup;
     if (wsl) {
-        command = wsl
+        command = wsl;
         args.unshift(rustup);
     }
     return child_process.spawn(command, args, options);

--- a/src/utils/child_process.ts
+++ b/src/utils/child_process.ts
@@ -22,25 +22,24 @@ export interface ExecChildProcessResult<TOut = string> {
     readonly stderr: TOut;
 }
 
-export async function execChildProcess(command: string): Promise<ExecChildProcessResult> {
-    const r: Promise<ExecChildProcessResult> = new Promise((resolve, reject) => {
-        child_process.exec(command, {
-            encoding: 'utf8',
-        }, (error, stdout, stderr) => {
-            if (!!error) {
-                reject(error);
-                return;
-            }
+// export async function execChildProcess(command: string): Promise<ExecChildProcessResult> {
+//     const r: Promise<ExecChildProcessResult> = new Promise((resolve, reject) => {
+//         child_process.exec(command, {
+//             encoding: 'utf8',
+//         }, (error, stdout, stderr) => {
+//             if (!!error) {
+//                 reject(error);
+//                 return;
+//             }
 
-            resolve({
-                stdout,
-                stderr,
-            });
-        });
-    });
-    return r;
-}
-
+//             resolve({
+//                 stdout,
+//                 stderr,
+//             });
+//         });
+//     });
+//     return r;
+// }
 
 export async function execFile(command: string, args: string[], options: child_process.ExecFileOptions): Promise<ExecChildProcessResult> {
     return new Promise<ExecChildProcessResult>((resolve, reject) => {
@@ -60,4 +59,22 @@ export async function execFile(command: string, args: string[], options: child_p
         });
 
     });
+}
+
+export async function run_rustup(rustup: string, args: string[], options: child_process.ExecFileOptions, wsl?: string): Promise<ExecChildProcessResult> {
+    let command: string = rustup;
+    if (wsl) {
+        command = wsl
+        args.unshift(rustup);
+    }
+    return execFile(command, args, options);
+}
+
+export function run_rustup_process(rustup: string, args: string[], options: child_process.ExecFileOptions, wsl?: string): child_process.ChildProcess {
+    let command: string = rustup;
+    if (wsl) {
+        command = wsl
+        args.unshift(rustup);
+    }
+    return child_process.spawn(command, args, options);
 }


### PR DESCRIPTION
To resolve all concerns with WSL (#160, #247, #144 ) and to fix my half-baked implementation GH-161 I have created this PR.  It should fix all of the problems with running this extension via WSL.

This is still WIP. The only missing thing is mapping filesystem paths from vscode language client (windows) to rls (wsl)

Example: 
I have simple rust application `kudu`. Lets run vscode on this application project.
Initialization, rls detection, (installation if needed) and so on works without problems. Hard part begins when rls tries to look for `Cargo.toml`. 

I got error 
```
Error reading manifest path: ErrorMessage { msg: "could not find `Cargo.toml` in `/c:/H_DEV/kudu` or any parent directory" }
```

It seems that to make this whole WSL thing working we need to make rls aware of wsl. Simplest way to fix it should be by introducing a filesystem paths mapping mechanism. So path `c:/H_DEV/kudu` should be mapped to `/mnt/c/H_DEV/kudu`. 

@Xanewok any ideas how to implement paths mapping in rls ?