### PR TITLE
Update rls component name to not include `-preview` suffix

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
                 },
                 "rust-client.rls-name": {
                     "type": "string",
-                    "default": "rls-preview",
+                    "default": "rls",
                     "description": "Name of the RLS rustup component."
                 },
                 "rust.sysroot": {


### PR DESCRIPTION
Fixes #461. This should be due to renamed `rls-preview` -> `rls` component for Rust 2018.

r? @nrc