### PR TITLE
Recommend new VS Code TSLint plugin

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"eg2.tslint"
+		"ms-vscode.vscode-typescript-tslint-plugin"
 	]
 }


### PR DESCRIPTION
From the description of eg2.tslint: "Note: We are about to deprecate this extension in favor of the vscode-typescript-tslint-plugin."

Update extensions.json in .vscode to respect this.