### PR TITLE
Always invoke RLS with rustup when using a rustup toolchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
                 "rust-client.rustupPath": {
                     "type": "string",
                     "default": "rustup",
-                    "description": "Path to rustup executable"
+                    "description": "Path to rustup executable. Ignored if rustup is disabled."
                 },
                 "rust-client.rlsPath": {
                     "type": [
@@ -180,7 +180,7 @@
                         "null"
                     ],
                     "default": null,
-                    "description": "Path to rls executable (only required for rls developers)"
+                    "description": "Override RLS path. Only required for RLS developers. If you set this and use rustup, you should also set `rust-client.channel` to ensure your RLS sees the right libraries. If you don't use rustup, make sure to set `rust-client.disableRustup`."
                 },
                 "rust-client.revealOutputChannelOn": {
                     "type": "string",
@@ -214,7 +214,7 @@
                         "nightly"
                     ],
                     "default": null,
-                    "description": "Rust channel to install RLS from. By default it will use the same channel as your currently open project"
+                    "description": "Rust channel to invoke rustup with. Ignored if rustup is disabled. By default, uses the same channel as your currently open project."
                 },
                 "rust.sysroot": {
                     "type": [


### PR DESCRIPTION
If we're using a rustup toolchain, we *must* invoke RLS through rustup so that rustup can set environment variables (`RUSTUP_HOME` and `RUSTUP_TOOLCHAIN`) to tell its rustc wrapper which toolchain is active. If these variables aren't set, the wrapper will sometimes choose the wrong toolchain when directory overrides are in use, causing build failures due to version mismatches.

This is true regardless of whether RLS itself was installed using rustup: as long as the toolchain is a rustup toolchain, any RLS binary needs to be run using rustup. However, we currently fail to do this when the user has specified a custom RLS path using `rust-client.rlsPath`. Instead, we call RLS directly.

Change our logic to treat "toolchain is from rustup" (controlled by `rust-client.disableRustup`) and "using custom RLS build" (controlled by `rust-client.rlsPath`) as two independent, orthogonal variables. Now, in any case where rustup is being used, RLS will be invoked using it.

This also has the nice effect of reducing the number of cases where we need to manually set `[DY]LD_LIBRARY_PATH`, as rustup does it for us when we use it to invoke RLS.

Tested with all combinations of rustup on/off and custom path set/unset.