### PR TITLE
Add an option for rust.trace.server.

### DIFF
--- a/package.json
+++ b/package.json
@@ -409,7 +409,7 @@
                         "verbose"
                     ],
                     "default": "off",
-                    "description": "Traces the communication between VS Code and the RLS.",
+                    "description": "Traces the communication between VS Code and the Rust language server.",
                     "scope": "window"
                 }
             }

--- a/package.json
+++ b/package.json
@@ -400,6 +400,17 @@
                     "default": true,
                     "description": "Show additional context in hover tooltips when available. This is often the type local variable declaration.",
                     "scope": "resource"
+                },
+                "rust.trace.server": {
+                    "type": "string",
+                    "enum": [
+                        "off",
+                        "messages",
+                        "verbose"
+                    ],
+                    "default": "off",
+                    "description": "Traces the communication between VS Code and the RLS.",
+                    "scope": "window"
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -221,7 +221,7 @@ class ClientWorkspace {
         };
 
         // Create the language client and start the client.
-        this.lc = new LanguageClient('Rust Language Server', serverOptions, clientOptions);
+        this.lc = new LanguageClient('rust', 'Rust Language Server', serverOptions, clientOptions);
 
         const promise = this.progressCounter();
 


### PR DESCRIPTION
Because this extension leverages `vscode-languageclient`,
it can provide nice logging support for the RLS "for free"
by exposing a setting named `rust.trace.server`.
See https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#logging-support-for-language-server
for details.