### PR TITLE
Added support for Windows Subsytem for Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,11 @@
                     "default": "rustup",
                     "description": "Path to rustup executable. Ignored if rustup is disabled."
                 },
+                "rust-client.useWSL": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When set to true, RLS is started within Windows Subsystem for Linux."
+                },
                 "rust-client.rlsPath": {
                     "type": [
                         "string",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -30,7 +30,6 @@ function fromStringToRevealOutputChannelOn(value: string): RevealOutputChannelOn
 }
 
 export class RLSConfiguration {
-
     public get rustupPath(): string {
         return this.configuration.get('rust-client.rustupPath', 'rustup');
     }
@@ -47,7 +46,7 @@ export class RLSConfiguration {
         return this.configuration.get<boolean>('rust-client.disableRustup', false);
     }
 
-    public get  revealOutputChannelOn(): RevealOutputChannelOn {
+    public get revealOutputChannelOn(): RevealOutputChannelOn {
         return RLSConfiguration.readRevealOutputChannelOn(this.configuration);
     }
 
@@ -90,7 +89,6 @@ export class RLSConfiguration {
     private constructor(configuration: WorkspaceConfiguration, wsPath: string) {
         this.configuration = configuration;
         this.wsPath = wsPath;
-
     }
 
     // Added ignoreChannel for readChannel function. Otherwise we end in an infinite loop. 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -91,7 +91,7 @@ export class RLSConfiguration {
         this.wsPath = wsPath;
     }
 
-    // Added ignoreChannel for readChannel function. Otherwise we end in an infinite loop. 
+    // Added ignoreChannel for readChannel function. Otherwise we end in an infinite loop.
     public rustupConfig(ignoreChannel: boolean = false): RustupConfig {
         return new RustupConfig(ignoreChannel ? '' : this.channel, this.rustupPath, this.useWSL);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,6 @@ import { execFile, ExecChildProcessResult } from './utils/child_process';
 export async function activate(context: ExtensionContext) {
     configureLanguage(context);
 
-
     workspace.onDidOpenTextDocument((doc) => didOpenTextDocument(doc, context));
     workspace.textDocuments.forEach((doc) => didOpenTextDocument(doc, context));
     workspace.onDidChangeWorkspaceFolders((e) => didChangeWorkspaceFolders(e, context));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -220,15 +220,15 @@ class ClientWorkspace {
                 cmdRun: true,
             },
             workspaceFolder: this.folder,
-            // Changes pathes between Windows and Windows Subsystem for Linux
-            uriConverters: !this.config.useWSL
-                ?
-                undefined :
-                {
-                    code2Protocol: (uri: Uri) => Uri.file(child_process.execFileSync('bash.exe', ['-i', '-c', `wslpath '${uri.fsPath}'`], {}).toString().trim()).toString(),
-                    protocol2Code: (wslPath: string) => Uri.file(child_process.execFileSync('bash.exe', ['-i', '-c', `wslpath -w ${Uri.parse(wslPath).path}`], {}).toString().trim())
-                }
         };
+
+        // Changes pathes between Windows and Windows Subsystem for Linux
+        if (this.config.useWSL) {
+            clientOptions.uriConverters = {
+                code2Protocol: (uri: Uri) => Uri.file(child_process.execFileSync('bash.exe', ['-i', '-c', `wslpath '${uri.fsPath}'`], {}).toString().trim()).toString(),
+                protocol2Code: (wslPath: string) => Uri.file(child_process.execFileSync('bash.exe', ['-i', '-c', `wslpath -w ${Uri.parse(wslPath).path}`], {}).toString().trim())
+            };
+        }
 
         // Create the language client and start the client.
         this.lc = new LanguageClient('rust', 'Rust Language Server', serverOptions, clientOptions);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -226,7 +226,7 @@ class ClientWorkspace {
         if (this.config.useWSL) {
             clientOptions.uriConverters = {
                 code2Protocol: (uri: Uri) => {
-                    let res = Uri.file(uriWindowsToWsl(uri.fsPath)).toString();
+                    const res = Uri.file(uriWindowsToWsl(uri.fsPath)).toString();
                     console.log(`code2Protocol for path ${uri.fsPath} -> ${res}`);
                     return res;
                 },
@@ -235,7 +235,7 @@ class ClientWorkspace {
                         wslPath = wslPath.substr('file://'.length);
                     }
 
-                    let res = Uri.file(uriWslToWindows(wslPath));
+                    const res = Uri.file(uriWslToWindows(wslPath));
                     console.log(`protocol2Code for path ${wslPath} -> ${res.fsPath}`);
                     return res;
                 },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ import {
     LanguageClient, LanguageClientOptions, Location, NotificationType,
     ServerOptions, ImplementationRequest
 } from 'vscode-languageclient';
-import { execFile, ExecChildProcessResult, run_rustup } from './utils/child_process';
+import { execFile, ExecChildProcessResult, run_rustup, run_rustup_process } from './utils/child_process';
 
 
 export async function activate(context: ExtensionContext) {
@@ -443,7 +443,7 @@ class ClientWorkspace {
                 await checkForRls(config);
             }
 
-            childProcess = child_process.spawn(config.path, ['run', config.channel, rls_path], { env });
+            childProcess = run_rustup_process(config.path, ['run', config.channel, rls_path], { env }, config.useWSL);
         }
         try {
             childProcess.on('error', err => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -225,8 +225,20 @@ class ClientWorkspace {
         // Changes paths between Windows and Windows Subsystem for Linux
         if (this.config.useWSL) {
             clientOptions.uriConverters = {
-                code2Protocol: (uri: Uri) => Uri.file(uriWindowsToWsl(uri.fsPath)).toString(),
-                protocol2Code: (wslPath: string) => Uri.file(uriWslToWindows(wslPath)),
+                code2Protocol: (uri: Uri) => {
+                    let res = Uri.file(uriWindowsToWsl(uri.fsPath)).toString();
+                    console.log(`code2Protocol for path ${uri.fsPath} -> ${res}`);
+                    return res;
+                },
+                protocol2Code: (wslPath: string) => {
+                    if (wslPath.startsWith('file://')) {
+                        wslPath = wslPath.substr('file://'.length);
+                    }
+
+                    let res = Uri.file(uriWslToWindows(wslPath));
+                    console.log(`protocol2Code for path ${wslPath} -> ${res.fsPath}`);
+                    return res;
+                },
             };
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import { rustupUpdate, ensureToolchain, checkForRls } from './rustup';
+import { rustupUpdate, ensureToolchain, checkForRls, run_rustup, run_rustup_process } from './rustup';
 import { startSpinner, stopSpinner } from './spinner';
 import { RLSConfiguration } from './configuration';
 import { activateTaskProvider, runCommand } from './tasks';
@@ -28,7 +28,7 @@ import {
     LanguageClient, LanguageClientOptions, Location, NotificationType,
     ServerOptions, ImplementationRequest
 } from 'vscode-languageclient';
-import { execFile, ExecChildProcessResult, run_rustup, run_rustup_process } from './utils/child_process';
+import { execFile, ExecChildProcessResult } from './utils/child_process';
 
 
 export async function activate(context: ExtensionContext) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import { rustupUpdate, ensureToolchain, checkForRls, run_rustup, run_rustup_process } from './rustup';
+import { rustupUpdate, ensureToolchain, checkForRls, runRustup, runRustupProcess } from './rustup';
 import { startSpinner, stopSpinner } from './spinner';
 import { RLSConfiguration } from './configuration';
 import { activateTaskProvider, runCommand } from './tasks';
@@ -222,7 +222,7 @@ class ClientWorkspace {
             workspaceFolder: this.folder,
         };
 
-        // Changes pathes between Windows and Windows Subsystem for Linux
+        // Changes paths between Windows and Windows Subsystem for Linux
         if (this.config.useWSL) {
             clientOptions.uriConverters = {
                 code2Protocol: (uri: Uri) => Uri.file(child_process.execFileSync('bash.exe', ['-i', '-c', `wslpath '${uri.fsPath}'`], {}).toString().trim()).toString(),
@@ -365,7 +365,7 @@ class ClientWorkspace {
                     'rustc', ['--print', 'sysroot'], { env }
                 );
             } else {
-                output = await run_rustup(
+                output = await runRustup(
                     this.config.rustupPath, ['run', await (this.config.channel), 'rustc', '--print', 'sysroot'], { env }, this.config.useWSL
                 );
             }
@@ -443,7 +443,7 @@ class ClientWorkspace {
                 await checkForRls(config);
             }
 
-            childProcess = run_rustup_process(config.path, ['run', config.channel, rls_path], { env }, config.useWSL);
+            childProcess = runRustupProcess(config.path, ['run', config.channel, rls_path], { env }, config.useWSL);
         }
         try {
             childProcess.on('error', err => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import { rustupUpdate, ensureToolchain, checkForRls, runRustup, runRustupProcess } from './rustup';
+import { rustupUpdate, ensureToolchain, checkForRls, execCmd, spawnProcess } from './rustup';
 import { startSpinner, stopSpinner } from './spinner';
 import { RLSConfiguration } from './configuration';
 import { activateTaskProvider, runCommand } from './tasks';
@@ -30,7 +30,6 @@ import {
     ServerOptions, ImplementationRequest
 } from 'vscode-languageclient';
 import { execFile, ExecChildProcessResult } from './utils/child_process';
-
 
 export async function activate(context: ExtensionContext) {
     configureLanguage(context);
@@ -377,7 +376,7 @@ class ClientWorkspace {
                     'rustc', ['--print', 'sysroot'], { env }
                 );
             } else {
-                output = await runRustup(
+                output = await execCmd(
                     this.config.rustupPath, ['run', await (this.config.channel), 'rustc', '--print', 'sysroot'], { env }, this.config.useWSL
                 );
             }
@@ -455,7 +454,7 @@ class ClientWorkspace {
                 await checkForRls(config);
             }
 
-            childProcess = runRustupProcess(config.path, ['run', config.channel, rls_path], { env }, config.useWSL);
+            childProcess = spawnProcess(config.path, ['run', config.channel, rls_path], { env }, config.useWSL);
         }
         try {
             childProcess.on('error', err => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import { rustupUpdate, ensureToolchain, checkForRls, runRustup, runRustupProcess
 import { startSpinner, stopSpinner } from './spinner';
 import { RLSConfiguration } from './configuration';
 import { activateTaskProvider, runCommand } from './tasks';
+import { uriWindowsToWsl, uriWslToWindows } from './utils/wslpath';
 
 import * as child_process from 'child_process';
 import * as fs from 'fs';
@@ -224,8 +225,8 @@ class ClientWorkspace {
         // Changes paths between Windows and Windows Subsystem for Linux
         if (this.config.useWSL) {
             clientOptions.uriConverters = {
-                code2Protocol: (uri: Uri) => Uri.file(child_process.execFileSync('bash.exe', ['-i', '-c', `wslpath '${uri.fsPath}'`], {}).toString().trim()).toString(),
-                protocol2Code: (wslPath: string) => Uri.file(child_process.execFileSync('bash.exe', ['-i', '-c', `wslpath -w ${Uri.parse(wslPath).path}`], {}).toString().trim())
+                code2Protocol: (uri: Uri) => Uri.file(uriWindowsToWsl(uri.fsPath)).toString(),
+                protocol2Code: (wslPath: string) => Uri.file(uriWslToWindows(wslPath)),
             };
         }
 

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -102,7 +102,7 @@ async function hasToolchain(config: RustupConfig): Promise<boolean> {
 async function tryToInstallToolchain(config: RustupConfig): Promise<void> {
     startSpinner('RLS', 'Installing toolchain…');
     try {
-        const { stdout, stderr } = await runRustup(config.path, ['toolchain', 'install'], {}, config.useWSL);
+        const { stdout, stderr } = await runRustup(config.path, ['toolchain', 'install', config.channel], {}, config.useWSL);
         console.log(stdout);
         console.log(stderr);
         stopSpinner(config.channel + ' toolchain installed successfully');

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -10,10 +10,9 @@
 
 'use strict';
 
-import * as child_process from 'child_process';
 import { window } from 'vscode';
 
-import { run_rustup, run_rustup_process, run_rustup_sync } from './utils/child_process';
+import { run_rustup, run_rustup_sync } from './utils/child_process';
 import { startSpinner, stopSpinner } from './spinner';
 
 export class RustupConfig {

--- a/src/utils/child_process.ts
+++ b/src/utils/child_process.ts
@@ -70,11 +70,10 @@ export function run_rustup_process(rustup: string, args: string[], options: chil
     return child_process.spawn(command, args, options);
 }
 
-function modifyParametersForWSL(originalCommand: string, originalArgs: string[]): { command: string, args: string[] } {
-    // When using Windows Subsystem for Linux call bash.exe in interactive mode
-    // Necessary, because on default rustup path is set in '.profile'
+function modifyParametersForWSL(command: string, args: string[]) {
+    args.unshift(command);
     return {
-        command: 'bash.exe',
-        args: ['-i', '-c', originalArgs.reduce((p, c) => `${p} ${c}`, originalCommand)]
+        command: 'wsl',
+        args: args
     };
 }

--- a/src/utils/child_process.ts
+++ b/src/utils/child_process.ts
@@ -32,48 +32,12 @@ export async function execFile(command: string, args: string[], options: child_p
                 reject(error);
                 return;
             }
+
             resolve({
                 stdout,
                 stderr,
             });
         });
+
     });
-}
-
-export async function run_rustup(rustup: string, args: string[], options: child_process.ExecFileOptions, useWSL?: boolean): Promise<ExecChildProcessResult> {
-    let command: string = rustup;
-
-    if (useWSL == true) {
-        ({ command: command, args: args } = modifyParametersForWSL(command, args));
-    }
-
-    return execFile(command, args, options);
-}
-
-export function run_rustup_sync(rustup: string, args: string[], options: child_process.ExecFileOptions, useWSL?: boolean): Buffer {
-    let command: string = rustup;
-
-    if (useWSL == true) {
-        ({ command: command, args: args } = modifyParametersForWSL(command, args));
-    }
-
-    return child_process.execFileSync(command, args, { ...options });
-}
-
-export function run_rustup_process(rustup: string, args: string[], options: child_process.ExecFileOptions, useWSL?: boolean): child_process.ChildProcess {
-    let command: string = rustup;
-
-    if (useWSL == true) {
-        ({ command: command, args: args } = modifyParametersForWSL(command, args));
-    }
-    
-    return child_process.spawn(command, args, options);
-}
-
-function modifyParametersForWSL(command: string, args: string[]) {
-    args.unshift(command);
-    return {
-        command: 'wsl',
-        args: args
-    };
 }

--- a/src/utils/wslpath.ts
+++ b/src/utils/wslpath.ts
@@ -1,0 +1,59 @@
+export function uriWslToWindows(wslUri: string): string {
+    let uriSegments = wslUri.split('/');
+    if (uriSegments.length < 3 || uriSegments[0].length != 0 || uriSegments[1] != 'mnt') {
+      return '';
+    }
+    uriSegments.shift();
+    if (uriSegments[uriSegments.length - 1] == '') {
+      uriSegments.pop();
+    }
+  
+    let disc_letter = uriSegments[1].toUpperCase();
+    if (!/^[A-Z]+$/.test(disc_letter)) {
+      return '';
+    }
+    uriSegments.shift(); // remove mnt
+    uriSegments.shift(); // remove disc letter
+  
+    let uriWindows = disc_letter + ':';
+    uriSegments.forEach(pathPart => {
+      uriWindows += '\\' + pathPart;
+    });
+  
+    if (uriWindows.length == 2) {
+      uriWindows += '\\'; // case where we have C: in result but we want C:\
+    }
+  
+    if (wslUri[wslUri.length - 1] == '/')
+      uriWindows += '\\';
+  
+    return uriWindows;
+  }
+  
+  export function uriWindowsToWsl(windowsUri: string): string {
+    let uriSegments = windowsUri.split('\\');
+    if (uriSegments.length < 2) {
+      return '';
+    }
+  
+    if (uriSegments[uriSegments.length - 1] == '') {
+      uriSegments.pop();
+    }
+  
+    let disc_letter = uriSegments[0][0].toLowerCase();
+    if (!/^[a-zA-Z]+$/.test(disc_letter)) {
+      return '';
+    }
+    uriSegments.shift();
+  
+    let uriWsl = '/mnt/' + disc_letter;
+    uriSegments.forEach(pathPart => {
+      uriWsl += '/' + pathPart;
+    });
+  
+    if (windowsUri[windowsUri.length - 1] == '\\')
+      uriWsl += '/';
+  
+    return uriWsl;
+  }
+  

--- a/src/utils/wslpath.ts
+++ b/src/utils/wslpath.ts
@@ -8,14 +8,14 @@ export function uriWslToWindows(wslUri: string): string {
       uriSegments.pop();
     }
   
-    const disc_letter = uriSegments[1].toUpperCase();
-    if (!/^[A-Z]+$/.test(disc_letter)) {
+    const disk_letter = uriSegments[1].toUpperCase();
+    if (!/^[A-Z]+$/.test(disk_letter)) {
       return '';
     }
     uriSegments.shift(); // remove mnt
-    uriSegments.shift(); // remove disc letter
+    uriSegments.shift(); // remove disk letter
   
-    let uriWindows = disc_letter + ':';
+    let uriWindows = disk_letter + ':';
     uriSegments.forEach(pathPart => {
       uriWindows += '\\' + pathPart;
     });
@@ -41,13 +41,13 @@ export function uriWslToWindows(wslUri: string): string {
       uriSegments.pop();
     }
   
-    const disc_letter = uriSegments[0][0].toLowerCase();
-    if (!/^[a-zA-Z]+$/.test(disc_letter)) {
+    const disk_letter = uriSegments[0][0].toLowerCase();
+    if (!/^[a-zA-Z]+$/.test(disk_letter)) {
       return '';
     }
     uriSegments.shift();
   
-    let uriWsl = '/mnt/' + disc_letter;
+    let uriWsl = '/mnt/' + disk_letter;
     uriSegments.forEach(pathPart => {
       uriWsl += '/' + pathPart;
     });

--- a/src/utils/wslpath.ts
+++ b/src/utils/wslpath.ts
@@ -1,5 +1,5 @@
 export function uriWslToWindows(wslUri: string): string {
-    let uriSegments = wslUri.split('/');
+    const uriSegments = wslUri.split('/');
     if (uriSegments.length < 3 || uriSegments[0].length != 0 || uriSegments[1] != 'mnt') {
       return '';
     }
@@ -8,7 +8,7 @@ export function uriWslToWindows(wslUri: string): string {
       uriSegments.pop();
     }
   
-    let disc_letter = uriSegments[1].toUpperCase();
+    const disc_letter = uriSegments[1].toUpperCase();
     if (!/^[A-Z]+$/.test(disc_letter)) {
       return '';
     }
@@ -24,14 +24,15 @@ export function uriWslToWindows(wslUri: string): string {
       uriWindows += '\\'; // case where we have C: in result but we want C:\
     }
   
-    if (wslUri[wslUri.length - 1] == '/')
+    if (wslUri[wslUri.length - 1] == '/') {
       uriWindows += '\\';
+    }
   
     return uriWindows;
   }
   
   export function uriWindowsToWsl(windowsUri: string): string {
-    let uriSegments = windowsUri.split('\\');
+    const uriSegments = windowsUri.split('\\');
     if (uriSegments.length < 2) {
       return '';
     }
@@ -40,7 +41,7 @@ export function uriWslToWindows(wslUri: string): string {
       uriSegments.pop();
     }
   
-    let disc_letter = uriSegments[0][0].toLowerCase();
+    const disc_letter = uriSegments[0][0].toLowerCase();
     if (!/^[a-zA-Z]+$/.test(disc_letter)) {
       return '';
     }
@@ -51,8 +52,9 @@ export function uriWslToWindows(wslUri: string): string {
       uriWsl += '/' + pathPart;
     });
   
-    if (windowsUri[windowsUri.length - 1] == '\\')
+    if (windowsUri[windowsUri.length - 1] == '\\') {
       uriWsl += '/';
+    }
   
     return uriWsl;
   }


### PR DESCRIPTION
Added support for WSL to use this extension on Windows while building on Linux. Solving the problem of translating the URI from windows filesystem to linux filesystem in #335 by defining uriConverter on the client options.
Additionally changed from defining a path to the executable for WLS to a boolean flag for WLS and instead always calling "bash.exe" with arguments "-i -c <command".

(I tried to rebase the original PR from @yisonPylkita, but failed catastrophically, because the code base changed a lot. Then I decided to start from scratch, because I changed quite a lot. I hope this is OK...)