### PR TITLE
Allow to not look for config in outermost nested folder.

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,6 +216,11 @@
                     "default": null,
                     "description": "Rust channel to invoke rustup with. Ignored if rustup is disabled. By default, uses the same channel as your currently open project."
                 },
+                "rust-client.nestedMultiRootConfigInOutermost": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "If one root workspace folder is nested in another root folder, look for the Rust config in the outermost root."
+                },
                 "rust.sysroot": {
                     "type": [
                         "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,9 @@ function didOpenTextDocument(document: TextDocument, context: ExtensionContext):
     if (!folder) {
         return;
     }
-    folder = getOuterMostWorkspaceFolder(folder);
+    if (workspace.getConfiguration().get<boolean>('rust-client.nestedMultiRootConfigInOutermost', true)) {
+        folder = getOuterMostWorkspaceFolder(folder);
+    }
     // folder = getCargoTomlWorkspace(folder, document.uri.fsPath);
     if (!folder) {
         stopSpinner(`RLS: Cargo.toml missing`);


### PR DESCRIPTION
This patch makes it configurable where the extension looks for Rust
config relevant to a file in case of nested top-level directories.

Example: imagine a multi-language project in `<project_path>` with a
Rust component under `<project_path>/<rust subdir>`. In this case a
developer might open a workspace that contains both `<project_path>` and
`<project_path>/<rust subdir>` as two different top-level directories
(the former for easy access to the Rust code they work on, the latter to
occasionally look up interfaces and docs from outside of the Rust
directory.

This setup doesn't work without this patch: the extension is looking for
Rust config always in the outermost of the possibly multiple workspace
folders that contain the file.

This patch makes the behavior configurable, so that for the setup above
one can set:

  `"rust-client.nestedMultiRootConfigInOutermost": false`

and have the extension working in `<rust subdir>` despite also having
`<project path>` open.

Fixes #495.