### PR TITLE
Change the description of rust-client.disableRustup in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
                 "rust-client.disableRustup": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Disable usage of rustup and use rustc/rls from PATH."
+                    "description": "Disable usage of rustup and use rustc/rls from PATH. If you use a specific nightly(nightly-YYYY-MM-DD), please set it to true."
                 },
                 "rust-client.channel": {
                     "type": [


### PR DESCRIPTION
### Change
`"description": "Disable usage of rustup and use rustc/rls from PATH."`
↓
`"description": "Disable usage of rustup and use rustc/rls from PATH. If you use a specific nightly(nightly-YYYY-MM-DD), please set it to true."`

### Background
In order to use the latest rls, I installed a nightly build on a specific day on which rls build succeeded.

![rustup_show](https://user-images.githubusercontent.com/20493693/52563189-06e78200-2e44-11e9-8a99-fec10f72d50b.PNG)

Then, the following error occurred.

![error_vscode-rls](https://user-images.githubusercontent.com/20493693/52558336-6e4a0580-2e35-11e9-9a55-4d24c7ec9df4.PNG)

The cause is that you are looking for sysroot with the rustup run nightly command.

![error_vscode-rls_2](https://user-images.githubusercontent.com/20493693/52558605-2e375280-2e36-11e9-836a-8e616b38c09e.png)

A simple solution to this problem is to write the following setting in setting.json.

`"rust-client.disableRustup": true`