### PR TITLE
Remove goto_def_racer_fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -321,12 +321,6 @@
                     "description": "Do not enable default Cargo features.",
                     "scope": "resource"
                 },
-                "rust.goto_def_racer_fallback": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Use racer as a fallback for goto def.",
-                    "scope": "resource"
-                },
                 "rust.racer_completion": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
What I understand, it has been replaced by the existing `racer_completion` config attribute: https://github.com/rust-lang/rls/pull/1152

Fixes #510