### PR TITLE
Change `ext install rust` to  `ext install rust-lang.rust`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ more details on building and debugging, etc., see [contributing.md](contributing
 
 * Install [rustup](https://www.rustup.rs/) (Rust toolchain manager).
 * Install this extension from [the VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust)
-  (or by entering `ext install rust` at the command palette <kbd>Ctrl</kbd>+<kbd>P</kbd>).
+  (or by entering `ext install rust-lang.rust` at the command palette <kbd>Ctrl</kbd>+<kbd>P</kbd>).
 * (Skip this step if you already have Rust projects that you'd like to work on.)
   Create a new Rust project by following [these instructions](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html).
 * Open a Rust project (`File > Add Folder to Workspace...`). Open the folder for the whole


### PR DESCRIPTION
So that when you press enter it installs the extension instead of starting a search in the extension browser for all extensions that contain `rust`