### PR TITLE
Show more details of what went wrong during the installation of RLS

### DIFF
--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -148,9 +148,13 @@ async function installRls(config: RustupConfig): Promise<void> {
             console.log(stderr);
             return null;
         }
-        catch (_e) {
-            window.showErrorMessage(`Could not install RLS component (${component})`);
-            const err = new Error(`installing ${component} failed`);
+        catch (e) {
+            let errorMessage = `Could not install RLS component (${component})`;
+            if (e.message) {
+                errorMessage += `, message: ${e.message}`;
+            }
+            window.showErrorMessage(errorMessage);
+            const err = new Error(`installing ${component} failed. Error: ${e}`);
             return err;
         }
     };


### PR DESCRIPTION
I'm getting a specific error (the rustup add component rls command itself is not running for whatever reason) that I only discovered after the changes I did in this pull request. 

This basically shows more details of the error in the error message popup shown by ` window.showErrorMessage`. It checks if a message exists in the exception and adds it to the text.

I think this is necessary so we can debug the error ourselves. I don't know why the error itself is happening, but the cause seems unrelated to the extension.

I don't know much typescript but there it is.