### PR TITLE
Set diagnostic collection name to 'rust'

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -211,6 +211,7 @@ class ClientWorkspace {
                 { language: 'rust', scheme: 'file', pattern: `${this.folder.uri.fsPath}/**/*` },
                 { language: 'rust', scheme: 'untitled', pattern: `${this.folder.uri.fsPath}/**/*` }
             ],
+            diagnosticCollectionName: 'rust',
             synchronize: { configurationSection: 'rust' },
             // Controls when to focus the channel rather than when to reveal it in the drop-down list
             revealOutputChannelOn: this.config.revealOutputChannelOn,


### PR DESCRIPTION
This fixes the duplicated diagnostics problem. Previously the generated
diagnostics from the RLS had a generated owner with a name like:
`_generated_diagnostic_collection_name_#0`, while the task-created had
those defined as `rust`. To unify that, we initialize the
`diagnosticCollectionName` to `'rust'`, which solves this problem.

Closes #133.