### PR TITLE
Add print! snippet and don't suggest "{}" in print(ln!) macro snippets

### DIFF
--- a/snippets/rust.json
+++ b/snippets/rust.json
@@ -32,14 +32,14 @@
     "print": {
         "prefix": "print",
         "body": [
-            "print!($1)$0"
+            "print!(\"$1\", $2)$0"
         ],
         "description": "Insert print!"
     },
     "println": {
         "prefix": "println",
         "body": [
-            "println!($1)$0"
+            "println!(\"$1\", $2)$0"
         ],
         "description": "Insert println!"
     },

--- a/snippets/rust.json
+++ b/snippets/rust.json
@@ -29,10 +29,17 @@
         ],
         "description": "Insert unreachable!"
     },
+    "print": {
+        "prefix": "print",
+        "body": [
+            "print!($1)$0"
+        ],
+        "description": "Insert print!"
+    },
     "println": {
         "prefix": "println",
         "body": [
-            "println!(\"${1:{\\}}\", $2)$0"
+            "println!($1)$0"
         ],
         "description": "Insert println!"
     },


### PR DESCRIPTION
Closes #370.

Applies feedback from https://github.com/rust-lang/rls-vscode/pull/370#discussion_r203935240.