### PR TITLE
Enable logging on Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -548,7 +548,7 @@ class ClientWorkspace {
   }
 
   warnOnRlsToml() {
-    const tomlPath = this.folder.uri.path + '/rls.toml';
+    const tomlPath = this.folder.uri.fsPath + '/rls.toml';
     fs.access(tomlPath, fs.constants.F_OK, err => {
       if (!err) {
         window.showWarningMessage(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -520,7 +520,7 @@ class ClientWorkspace {
       });
 
       if (this.config.logToFile) {
-        const logPath = this.folder.uri.path + '/rls' + Date.now() + '.log';
+        const logPath = this.folder.uri.fsPath + '/rls' + Date.now() + '.log';
         const logStream = fs.createWriteStream(logPath, { flags: 'w+' });
         logStream
           .on('open', function(_f) {


### PR DESCRIPTION
Before the code used path, which yields an illegal path name on Windows (starting with /C:/...). fsPath gives the proper pathname.

This change should be tested on Linux before it is merged. I don't have a Linux available right now to test it.