### PR TITLE
Patch for 111e12c by renaming language id from rust to rust-client.

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,6 +224,17 @@
                     "default": null,
                     "description": "Rust channel to invoke rustup with. Ignored if rustup is disabled. By default, uses the same channel as your currently open project."
                 },
+                "rust-client.trace.server": {
+                    "type": "string",
+                    "enum": [
+                        "off",
+                        "messages",
+                        "verbose"
+                    ],
+                    "default": "off",
+                    "description": "Traces the communication between VS Code and the Rust language server.",
+                    "scope": "window"
+                },
                 "rust.sysroot": {
                     "type": [
                         "string",
@@ -402,17 +413,6 @@
                     "default": true,
                     "description": "Show additional context in hover tooltips when available. This is often the type local variable declaration.",
                     "scope": "resource"
-                },
-                "rust.trace.server": {
-                    "type": "string",
-                    "enum": [
-                        "off",
-                        "messages",
-                        "verbose"
-                    ],
-                    "default": "off",
-                    "description": "Traces the communication between VS Code and the Rust language server.",
-                    "scope": "window"
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -268,7 +268,7 @@ class ClientWorkspace {
 
     // Create the language client and start the client.
     this.lc = new LanguageClient(
-      'rust',
+      'rust-client',
       'Rust Language Server',
       serverOptions,
       clientOptions,


### PR DESCRIPTION
The language id seems to be simply an identifier and unused elsewhere.

Fixes rust-lang/rls-vscode#530.

It's tested and appears to be working.