### PR TITLE
Allow to not look for config in outermost nested folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,6 +235,11 @@
                     "description": "Traces the communication between VS Code and the Rust language server.",
                     "scope": "window"
                 },
+                "rust-client.nestedMultiRootConfigInOutermost": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "If one root workspace folder is nested in another root folder, look for the Rust config in the outermost root."
+                },
                 "rust.sysroot": {
                     "type": [
                         "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,7 +79,9 @@ function didOpenTextDocument(
   if (!folder) {
     return;
   }
-  folder = getOuterMostWorkspaceFolder(folder);
+  if (workspace.getConfiguration().get<boolean>('rust-client.nestedMultiRootConfigInOutermost', true)) {
+    folder = getOuterMostWorkspaceFolder(folder);
+  }
   // folder = getCargoTomlWorkspace(folder, document.uri.fsPath);
   if (!folder) {
     stopSpinner(`RLS: Cargo.toml missing`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,7 +79,11 @@ function didOpenTextDocument(
   if (!folder) {
     return;
   }
-  if (workspace.getConfiguration().get<boolean>('rust-client.nestedMultiRootConfigInOutermost', true)) {
+  if (
+    workspace
+      .getConfiguration()
+      .get<boolean>('rust-client.nestedMultiRootConfigInOutermost', true)
+  ) {
     folder = getOuterMostWorkspaceFolder(folder);
   }
   // folder = getCargoTomlWorkspace(folder, document.uri.fsPath);


### PR DESCRIPTION
Closes #497.
Fixes #495.

@ppiet thanks for the patch and sorry it took a while for me to respond. Since everything changed slightly (formatting was enforced) I figured I'd just rebase this myself not to bother you; I'll go ahead and merge this if you don't mind.