### PR TITLE
Fix - Windows paths with spaces

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -256,7 +256,7 @@ class ClientWorkspace {
         protocol2Code: (wslPath: string) => {
           if (wslPath.startsWith('file://')) {
             wslPath = wslPath.substr('file://'.length);
-            wslPath = wslPath.replace('%20', ' ');
+            wslPath = wslPath.replace(/%20/g, ' ');
           }
 
           const res = Uri.file(uriWslToWindows(wslPath));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -256,6 +256,7 @@ class ClientWorkspace {
         protocol2Code: (wslPath: string) => {
           if (wslPath.startsWith('file://')) {
             wslPath = wslPath.substr('file://'.length);
+            wslPath = wslPath.replace('%20', ' ');
           }
 
           const res = Uri.file(uriWslToWindows(wslPath));


### PR DESCRIPTION
Fixes #550 
protocol2Code does not handle paths with spaces correctly