### PR TITLE
Decode URL under WSL on Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -254,14 +254,11 @@ class ClientWorkspace {
           console.log(`code2Protocol for path ${uri.fsPath} -> ${res}`);
           return res;
         },
-        protocol2Code: (wslPath: string) => {
-          if (wslPath.startsWith('file://')) {
-            wslPath = wslPath.substr('file://'.length);
-          }
-
-          const res = Uri.file(uriWslToWindows(wslPath));
-          console.log(`protocol2Code for path ${wslPath} -> ${res.fsPath}`);
-          return res;
+        protocol2Code: (wslUri: string) => {
+          const urlDecodedPath = Uri.parse(wslUri).path;
+          const winPath = Uri.file(uriWslToWindows(urlDecodedPath));
+          console.log(`protocol2Code for path ${wslUri} -> ${winPath.fsPath}`);
+          return winPath;
         },
       };
     }

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -219,14 +219,11 @@ export function parseActiveToolchain(rustupOutput: string): string {
   throw new Error(`couldn't find active toolchains`);
 }
 
-export async function getVersion(
-  cwd: string,
-  config: RustupConfig,
-): Promise<string> {
+export async function getVersion(config: RustupConfig): Promise<string> {
   const versionRegex = /rustup ([0-9]+\.[0-9]+\.[0-9]+)/;
   const execFile = withWsl(config.useWSL).execFile;
 
-  const output = await execFile(config.path, ['--version'], { cwd });
+  const output = await execFile(config.path, ['--version']);
   const versionMatch = output.stdout.toString().match(versionRegex);
   if (versionMatch && versionMatch.length >= 2) {
     return versionMatch[1];

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -90,9 +90,14 @@ async function hasToolchain(config: RustupConfig): Promise<boolean> {
     return stdout.includes(config.channel);
   } catch (e) {
     console.log(e);
-    // rustup not present
+    const rustupFoundButNotInWSLMode =
+      config.useWSL && (await hasRustup({ useWSL: false, ...config }));
+
     window.showErrorMessage(
-      'Rustup not available. Install from https://www.rustup.rs/',
+      rustupFoundButNotInWSLMode
+        ? `Rustup is installed but can't be found under WSL. Ensure that
+        invoking \`wsl rustup\` works correctly.`
+        : 'Rustup not available. Install from https://www.rustup.rs/',
     );
     throw e;
   }
@@ -230,6 +235,15 @@ export async function getVersion(config: RustupConfig): Promise<string> {
   } else {
     throw new Error("Couldn't parse rustup version");
   }
+}
+
+/**
+ * Returns whether Rustup is invokable and available.
+ */
+export function hasRustup(config: RustupConfig): Promise<boolean> {
+  return getVersion(config)
+    .then(() => true)
+    .catch(() => false);
 }
 
 /**

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -144,6 +144,7 @@ async function hasRlsComponents(config: RustupConfig): Promise<boolean> {
   } catch (e) {
     console.log(e);
     window.showErrorMessage(`Can't detect RLS components: ${e.message}`);
+    stopSpinner("Can't detect RLS components");
     throw e;
   }
 }

--- a/src/test/rustup.test.ts
+++ b/src/test/rustup.test.ts
@@ -16,7 +16,7 @@ const config: rustup.RustupConfig = {
 
 suite('Rustup Tests', () => {
   test('getVersion', async () => {
-    const version = await rustup.getVersion('.', config);
+    const version = await rustup.getVersion(config);
     assert(rustupVersion.includes(`rustup ${version}`));
   });
   test('getActiveChannel', async () => {


### PR DESCRIPTION
Simply stripping `file://` is not enough when converting the remaining path to Windows-style, as URL can encode special characters (e.g. ` ` -> `%20`). This PR decodes the special characters using the VSCode `Uri` module (with which we encode those paths ourselves in the first place), extracts the decoded path and only then performs the conversion.

Also contains some minuscule fixes for WSL-enabled workflow.

Tested this myself (on directories with ` ` or a `#`) but ideally we should also test this in CI; however adding a WSL will add another 10 mins to the Windows run (which already takes 10 minutes already due to slow installation of `rust-docs` component), so not doing this as part of this PR.

Closes #550.
Closes #551.
Closes #553.