### PR TITLE
Remove old `rls.findImpls` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,6 @@ Some highlights:
 
 ## Features
 
-### Commands
-
-Commands can be found in the command palette <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>. We provide the
-following commands:
-
-* `Find Implementations` - Find locations of `impl` blocks for traits, structs, and enums.
-  Usefull to find all structs implementing a specific trait or all traits implemented for a struct.
-  Select a type when running the command.
-
-
 ### Snippets
 
 Snippets are code templates which expand into common boilerplate. Intellisense

--- a/package.json
+++ b/package.json
@@ -81,12 +81,6 @@
         ],
         "commands": [
             {
-                "command": "rls.findImpls",
-                "title": "Find Implementations",
-                "description": "Show impl blocks for trait, struct, or enum",
-                "category": "Rust"
-            },
-            {
                 "command": "rls.update",
                 "title": "Update the RLS",
                 "description": "Use Rustup to update Rust, the RLS, and required data",
@@ -99,15 +93,6 @@
                 "category": "Rust"
             }
         ],
-        "menus": {
-            "editor/context": [
-                {
-                    "command": "rls.findImpls",
-                    "when": "editorLangId == rust && editorHasReferenceProvider",
-                    "group": "navigation@4"
-                }
-            ]
-        },
         "taskDefinitions": [
             {
                 "type": "cargo",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -298,44 +298,6 @@ class ClientWorkspace {
       return;
     }
 
-    const findImplsDisposable = commands.registerTextEditorCommand(
-      'rls.findImpls',
-      async (textEditor: TextEditor, _edit: TextEditorEdit) => {
-        if (!this.lc) {
-          return;
-        }
-        await this.lc.onReady();
-        // Prior to https://github.com/rust-lang-nursery/rls/pull/936 we used a custom
-        // LSP message - if the implementation provider is specified this means we can use the 3.6 one.
-        const useLSPRequest =
-          this.lc.initializeResult &&
-          this.lc.initializeResult.capabilities.implementationProvider === true;
-        const request = useLSPRequest
-          ? ImplementationRequest.type.method
-          : 'rustDocument/implementations';
-
-        const params = this.lc.code2ProtocolConverter.asTextDocumentPositionParams(
-          textEditor.document,
-          textEditor.selection.active,
-        );
-        let locations: Location[];
-        try {
-          locations = await this.lc.sendRequest<Location[]>(request, params);
-        } catch (reason) {
-          window.showWarningMessage(`find implementations failed: ${reason}`);
-          return;
-        }
-
-        return commands.executeCommand(
-          'editor.action.showReferences',
-          textEditor.document.uri,
-          textEditor.selection.active,
-          locations.map(this.lc.protocol2CodeConverter.asLocation),
-        );
-      },
-    );
-    this.disposables.push(findImplsDisposable);
-
     const rustupUpdateDisposable = commands.registerCommand(
       'rls.update',
       () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,8 +8,6 @@ import {
   IndentAction,
   languages,
   TextDocument,
-  TextEditor,
-  TextEditorEdit,
   Uri,
   window,
   workspace,
@@ -17,10 +15,8 @@ import {
   WorkspaceFoldersChangeEvent,
 } from 'vscode';
 import {
-  ImplementationRequest,
   LanguageClient,
   LanguageClientOptions,
-  Location,
   NotificationType,
   ServerOptions,
 } from 'vscode-languageclient';


### PR DESCRIPTION
This was used before LSP has considered (and now stabilised)
a 'go to implementation' request. Handling this via LSP,
even at the cost of command disappearing from the context menu [1],
is preferred than using a global command. We'd have to maintain an
extra mapping and guess which RLS server is responsible for the file
for which a request has been made. This is hacky and not guaranteed
to be correct; meanwhile we get errors in multi-root workspaces
whenever we open more than one folder due to each instance trying to
register a global command under the same identifier.

The clean solution is to remove this extra command and use the standard
Go to Implementation (under Go > Go to Implementation [Ctrl + F12])
while we wait for the user configurable menus [2] to land.

[1]: https://github.com/Microsoft/vscode/pull/54317
[2]: https://github.com/Microsoft/vscode/issues/9285

Addresses #560 (doesn't fix unavailable commands in second directory)
Closes #437.