### PR TITLE
customize wsl mount point

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -118,4 +118,13 @@ export class RLSConfiguration {
       useWSL: this.useWSL,
     };
   }
+
+  /**
+   * Get wsl mount point when useWsl enable
+   */
+  public get wslMountPoint(): string {
+    return (
+      this.configuration.get<string>('rust-client.wslMountPoint') || '/mnt/'
+    );
+  }
 }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -10,6 +10,8 @@ import {
   WorkspaceFolder,
 } from 'vscode';
 
+import { RLSConfiguration } from './configuration';
+
 /**
  * Displayed identifier associated with each task.
  */
@@ -42,7 +44,9 @@ export interface Execution {
  */
 function createShellExecution(execution: Execution): ShellExecution {
   const { binary, command, args, cwd, env } = execution;
-  const cmdLine = `${command || binary} ${args.join(' ')}`;
+  const cmdLine = RLSConfiguration.loadFromWorkspace('').useWSL
+    ? `wsl.exe ${command || binary} ${args.join(' ')}`
+    : `${command || binary} ${args.join(' ')}`;
   return new ShellExecution(cmdLine, { cwd, env });
 }
 

--- a/src/test/utils/wslpath.test.ts
+++ b/src/test/utils/wslpath.test.ts
@@ -2,32 +2,32 @@ import * as assert from 'assert';
 
 import * as wslpath from '../../utils/wslpath';
 
-function mkConverterCheck(converter: (arg: string) => string) {
-  return (from: string, to: string) => assert.equal(converter(from), to);
+function mkConverterCheck(converter: (arg: string, m: string) => string) {
+  return (from: string, to: string) => assert.equal(converter(from, '/'), to);
 }
 
 suite('WSL path conversion', () => {
   test('uriWindowsToWsl', () => {
     const check = mkConverterCheck(wslpath.uriWindowsToWsl);
     // Basic test
-    check('C:\\Program Files\\somedir', '/mnt/c/Program Files/somedir');
+    check('C:\\Program Files\\somedir', '/c/Program Files/somedir');
     // Trailing slash
-    check('C:\\Program Files\\somedir\\', '/mnt/c/Program Files/somedir/');
+    check('C:\\Program Files\\somedir\\', '/c/Program Files/somedir/');
     // Different disk letter
-    check('z:\\', '/mnt/z/');
-    check('C:\\', '/mnt/c/');
+    check('z:\\', '/z/');
+    check('C:\\', '/c/');
   });
   test('uriWslToWindows', () => {
     const check = mkConverterCheck(wslpath.uriWslToWindows);
 
     // Basic test
-    check('/mnt/c/Program Files/somedir', 'C:\\Program Files\\somedir');
+    check('/c/Program Files/somedir', 'C:\\Program Files\\somedir');
     // Trailing slash
-    check('/mnt/c/Program Files/somedir/', 'C:\\Program Files\\somedir\\');
+    check('/c/Program Files/somedir/', 'C:\\Program Files\\somedir\\');
     // Uppercase drive letter
-    check('/mnt/C/Some Directory', 'C:\\Some Directory');
+    check('/C/Some Directory', 'C:\\Some Directory');
     // FIXME: Should be `C:\\`? (single slash)
-    check('/mnt/C/', 'C:\\\\');
-    check('/mnt/z/', 'Z:\\\\');
+    check('/C/', 'C:\\');
+    check('/z/', 'Z:\\');
   });
 });

--- a/src/utils/wslpath.ts
+++ b/src/utils/wslpath.ts
@@ -6,25 +6,18 @@ export function modifyParametersForWSL(command: string, args: string[]) {
   };
 }
 
-export function uriWslToWindows(wslUri: string): string {
-  const uriSegments = wslUri.split('/');
-  if (
-    uriSegments.length < 3 ||
-    uriSegments[0].length !== 0 ||
-    uriSegments[1] !== 'mnt'
-  ) {
+export function uriWslToWindows(wslUri: string, mountPoint: string): string {
+  const uri = wslUri.startsWith(mountPoint)
+    ? wslUri.substring(mountPoint.length)
+    : wslUri;
+  if (uri === '') {
     return '';
   }
-  uriSegments.shift();
-  if (uriSegments[uriSegments.length - 1] === '') {
-    uriSegments.pop();
-  }
-
-  const diskLetter = uriSegments[1].toUpperCase();
+  const uriSegments = uri.split('/');
+  const diskLetter = uriSegments[0].toUpperCase();
   if (!/^[A-Z]+$/.test(diskLetter)) {
     return '';
   }
-  uriSegments.shift(); // remove mnt
   uriSegments.shift(); // remove disk letter
 
   let uriWindows = diskLetter + ':';
@@ -36,14 +29,13 @@ export function uriWslToWindows(wslUri: string): string {
     uriWindows += '\\'; // case where we have C: in result but we want C:\
   }
 
-  if (wslUri[wslUri.length - 1] === '/') {
-    uriWindows += '\\';
-  }
-
   return uriWindows;
 }
 
-export function uriWindowsToWsl(windowsUri: string): string {
+export function uriWindowsToWsl(
+  windowsUri: string,
+  mountPoint: string,
+): string {
   const uriSegments = windowsUri.split('\\');
   if (uriSegments.length < 2) {
     return '';
@@ -59,7 +51,7 @@ export function uriWindowsToWsl(windowsUri: string): string {
   }
   uriSegments.shift();
 
-  let uriWsl = '/mnt/' + diskLetter;
+  let uriWsl = mountPoint + diskLetter;
   uriSegments.forEach(pathPart => {
     uriWsl += '/' + pathPart;
   });


### PR DESCRIPTION
Allow customize wsl mount point via **rust-client.wslMountPoint.**, with some fix in path translation and cargo task.