### PR TITLE
Spawn user-provided RLS and Rustup in a shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Expand `~` in `rust-client.{rustup,rls}Path` settings
+
 ### 0.6.1 - 2019-04-04
 
 * Fix Cargo task auto-detection

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -346,10 +346,9 @@ class ClientWorkspace {
 
     const rustcPrintSysroot = () =>
       this.config.rustupDisabled
-        ? wslWrapper.execFile('rustc', ['--print', 'sysroot'], { env })
-        : wslWrapper.execFile(
-            this.config.rustupPath,
-            ['run', this.config.channel, 'rustc', '--print', 'sysroot'],
+        ? wslWrapper.exec('rustc --print sysroot', { env })
+        : wslWrapper.exec(
+            `${this.config.rustupPath} run ${this.config.channel} rustc --print sysroot`,
             { env },
           );
 
@@ -419,7 +418,11 @@ class ClientWorkspace {
       console.info(`running without rustup: ${rlsPath}`);
       const env = await makeRlsEnv();
 
-      childProcess = child_process.spawn(rlsPath, [], { env, cwd });
+      childProcess = child_process.spawn(rlsPath, [], {
+        env,
+        cwd,
+        shell: true,
+      });
     } else {
       console.info(`running with rustup: ${rlsPath}`);
       const config = this.config.rustupConfig();
@@ -436,7 +439,7 @@ class ClientWorkspace {
       childProcess = withWsl(config.useWSL).spawn(
         config.path,
         ['run', config.channel, rlsPath],
-        { env, cwd },
+        { env, cwd, shell: true },
       );
     }
 

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -24,9 +24,9 @@ export async function rustupUpdate(config: RustupConfig) {
   startSpinner('RLS', 'Updating…');
 
   try {
-    const { stdout } = await withWsl(config.useWSL).execFile(config.path, [
-      'update',
-    ]);
+    const { stdout } = await withWsl(config.useWSL).exec(
+      `${config.path} update`,
+    );
 
     // This test is imperfect because if the user has multiple toolchains installed, they
     // might have one updated and one unchanged. But I don't want to go too far down the
@@ -83,10 +83,9 @@ export async function checkForRls(config: RustupConfig) {
 
 async function hasToolchain(config: RustupConfig): Promise<boolean> {
   try {
-    const { stdout } = await withWsl(config.useWSL).execFile(config.path, [
-      'toolchain',
-      'list',
-    ]);
+    const { stdout } = await withWsl(config.useWSL).exec(
+      `${config.path} toolchain list`,
+    );
     return stdout.includes(config.channel);
   } catch (e) {
     console.log(e);
@@ -130,7 +129,7 @@ async function tryToInstallToolchain(config: RustupConfig) {
  */
 async function listComponents(config: RustupConfig): Promise<string[]> {
   return withWsl(config.useWSL)
-    .execFile(config.path, ['component', 'list', '--toolchain', config.channel])
+    .exec(`${config.path} component list --toolchain ${config.channel}`)
     .then(({ stdout }) =>
       stdout
         .toString()
@@ -226,9 +225,8 @@ export function parseActiveToolchain(rustupOutput: string): string {
 
 export async function getVersion(config: RustupConfig): Promise<string> {
   const versionRegex = /rustup ([0-9]+\.[0-9]+\.[0-9]+)/;
-  const execFile = withWsl(config.useWSL).execFile;
 
-  const output = await execFile(config.path, ['--version']);
+  const output = await withWsl(config.useWSL).exec(`${config.path} --version`);
   const versionMatch = output.stdout.toString().match(versionRegex);
   if (versionMatch && versionMatch.length >= 2) {
     return versionMatch[1];
@@ -259,7 +257,7 @@ export function getActiveChannel(wsPath: string, config: RustupConfig): string {
   try {
     // `rustup show active-toolchain` is available since rustup 1.12.0
     activeChannel = withWsl(config.useWSL)
-      .execFileSync(config.path, ['show', 'active-toolchain'], { cwd: wsPath })
+      .execSync(`${config.path} show active-toolchain`, { cwd: wsPath })
       .toString()
       .trim();
     // Since rustup 1.17.0 if the active toolchain is the default, we're told
@@ -270,7 +268,7 @@ export function getActiveChannel(wsPath: string, config: RustupConfig): string {
   } catch (e) {
     // Possibly an old rustup version, so try rustup show
     const showOutput = withWsl(config.useWSL)
-      .execFileSync(config.path, ['show'], { cwd: wsPath })
+      .execSync(`${config.path} show`, { cwd: wsPath })
       .toString();
     activeChannel = parseActiveToolchain(showOutput);
   }

--- a/src/utils/child_process.ts
+++ b/src/utils/child_process.ts
@@ -3,11 +3,11 @@ import * as util from 'util';
 
 import { modifyParametersForWSL } from './wslpath';
 
-const execFileAsync = util.promisify(child_process.execFile);
+const execAsync = util.promisify(child_process.exec);
 
 export interface SpawnFunctions {
-  execFile: typeof execFileAsync;
-  execFileSync: typeof child_process.execFileSync;
+  exec: typeof execAsync;
+  execSync: typeof child_process.execSync;
   spawn: typeof child_process.spawn;
   modifyArgs: (
     command: string,
@@ -18,14 +18,14 @@ export interface SpawnFunctions {
 export function withWsl(withWsl: boolean): SpawnFunctions {
   return withWsl
     ? {
-        execFile: withWslModifiedParameters(execFileAsync),
-        execFileSync: withWslModifiedParameters(child_process.execFileSync),
+        exec: withWslModifiedParameters(execAsync),
+        execSync: withWslModifiedParameters(child_process.execSync),
         spawn: withWslModifiedParameters(child_process.spawn),
         modifyArgs: modifyParametersForWSL,
       }
     : {
-        execFile: execFileAsync,
-        execFileSync: child_process.execFileSync,
+        exec: execAsync,
+        execSync: child_process.execSync,
         spawn: child_process.spawn,
         modifyArgs: (command: string, args: string[]) => ({ command, args }),
       };


### PR DESCRIPTION
This allows us to expand (and therefore use) `~` in these paths. 

Closes #577