### PR TITLE
Deprecate in-extension WSL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 * Expand `~` in `rust-client.{rustup,rls}Path` settings
+* Deprecate `rust-client.useWSL` setting (use [Remote - WSL](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) extension instead)
 
 ### 0.6.1 - 2019-04-04
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,4 +1,4 @@
-import { workspace, WorkspaceConfiguration } from 'vscode';
+import { window, workspace, WorkspaceConfiguration } from 'vscode';
 import { RevealOutputChannelOn } from 'vscode-languageclient';
 
 import { getActiveChannel, RustupConfig } from './rustup';
@@ -26,6 +26,14 @@ export class RLSConfiguration {
   private constructor(configuration: WorkspaceConfiguration, wsPath: string) {
     this.configuration = configuration;
     this.wsPath = wsPath;
+
+    if (this.configuration.get<boolean>('rust-client.useWSL')) {
+      window.showWarningMessage(
+        'Option `rust-client.useWsl` is enabled for this workspace, which is DEPRECATED.\
+        For a complete and first-class WSL support try Remote - WSL extension \
+        extension (https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl)',
+      );
+    }
   }
 
   public static loadFromWorkspace(wsPath: string): RLSConfiguration {


### PR DESCRIPTION
Our current implementation is a best effort one - we run path translation ourselves and execute the commands via wrappers, which is bug-prone notoriously hard to get right.

Since introducing this feature ourseelves, Microsoft has created a [Remote - WSL]() extension which allows to run all the relevant tooling in WSL - this means no path translation, correct mount point detection and so on.

Because of that, I'd like us to deprecate our custom in-extension WSL support and recommend using the official WSL one instead.

Currently opened issues related to WSL:
- https://github.com/rust-lang/rls-vscode/pull/568
- https://github.com/rust-lang/rls-vscode/issues/610
- https://github.com/rust-lang/rls-vscode/issues/585
- https://github.com/rust-lang/rls-vscode/issues/575
- https://github.com/rust-lang/rls-vscode/issues/570