### PR TITLE
reintroduce multi project setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,6 +219,11 @@
                     "default": true,
                     "description": "If one root workspace folder is nested in another root folder, look for the Rust config in the outermost root."
                 },
+                "rust-client.enableMultiProjectSetup": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Allow multiple projects in the same folder, along with remove the constraint that the cargo.toml must be located at the root. (Experimental: might not work for certain setups)"
+                },
                 "rust.sysroot": {
                     "type": [
                         "string",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -118,6 +118,10 @@ export class RLSConfiguration {
     return this.configuration.get<string>('rust-client.rlsPath');
   }
 
+  public get multiProjectEnabled(): boolean {
+    return this.configuration.get<boolean>('rust-client.enableMultiProjectSetup', false);
+  }
+
   // Added ignoreChannel for readChannel function. Otherwise we end in an infinite loop.
   public rustupConfig(ignoreChannel: boolean = false): RustupConfig {
     return {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -119,7 +119,10 @@ export class RLSConfiguration {
   }
 
   public get multiProjectEnabled(): boolean {
-    return this.configuration.get<boolean>('rust-client.enableMultiProjectSetup', false);
+    return this.configuration.get<boolean>(
+      'rust-client.enableMultiProjectSetup',
+      false,
+    );
   }
 
   // Added ignoreChannel for readChannel function. Otherwise we end in an infinite loop.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -518,7 +518,7 @@ async function warnOnMissingCargoToml() {
 
   if (files.length < 1) {
     window.showWarningMessage(
-      'A Cargo.toml file must be at the root of the workspace in order to support all features',
+      'A Cargo.toml file must be at the root of the workspace in order to support all features. Alternatively set rust-client.enableMultiProjectSetup=true in settings.',
     );
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import {
   ServerOptions,
 } from 'vscode-languageclient';
 
+import * as workspace_util from './workspace_util';
 import { RLSConfiguration } from './configuration';
 import { SignatureHelpProvider } from './providers/signatureHelpProvider';
 import { checkForRls, ensureToolchain, rustupUpdate } from './rustup';
@@ -123,40 +124,6 @@ function sortedWorkspaceFolders(): string[] {
   return _sortedWorkspaceFolders || [];
 }
 
-function getCargoTomlWorkspace(
-  curWorkspace: WorkspaceFolder,
-  filePath: string,
-): WorkspaceFolder {
-  if (!curWorkspace) {
-    return curWorkspace;
-  }
-
-  const workspaceRoot = path.parse(curWorkspace.uri.fsPath).dir;
-  const rootManifest = path.join(workspaceRoot, 'Cargo.toml');
-  if (fs.existsSync(rootManifest)) {
-    return curWorkspace;
-  }
-
-  let current = filePath;
-
-  while (true) {
-    const old = current;
-    current = path.dirname(current);
-    if (old === current) {
-      break;
-    }
-    if (workspaceRoot === path.parse(current).dir) {
-      break;
-    }
-
-    const cargoPath = path.join(current, 'Cargo.toml');
-    if (fs.existsSync(cargoPath)) {
-      return { ...curWorkspace, uri: Uri.parse(current) };
-    }
-  }
-
-  return curWorkspace;
-}
 
 function getOuterMostWorkspaceFolder(folder: WorkspaceFolder): WorkspaceFolder {
   const sorted = sortedWorkspaceFolders();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -175,7 +175,7 @@ function whenChangingWorkspaceFolders(
 // Don't use URI as it's unreliable the same path might not become the same URI.
 const workspaces: Map<string, ClientWorkspace> = new Map();
 let activeWorkspace: ClientWorkspace | null;
-let commandsUnregistered: boolean = true;
+let commandsRegistered: boolean = false;
 
 // We run one RLS and one corresponding language client per workspace folder
 // (VSCode workspace, not Cargo workspace). This class contains all the per-client
@@ -279,7 +279,7 @@ class ClientWorkspace {
     }
 
     this.disposables.forEach(d => d.dispose());
-    commandsUnregistered = true;
+    commandsRegistered = false;
   }
 
   private registerCommands(
@@ -289,11 +289,11 @@ class ClientWorkspace {
     if (!this.lc) {
       return;
     }
-    if (multiProjectEnabled && !commandsUnregistered) {
+    if (multiProjectEnabled && commandsRegistered) {
       return;
     }
 
-    commandsUnregistered = false;
+    commandsRegistered = true;
     const rustupUpdateDisposable = commands.registerCommand(
       'rls.update',
       () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,6 @@ import {
   ServerOptions,
 } from 'vscode-languageclient';
 
-import * as workspace_util from './workspace_util';
 import { RLSConfiguration } from './configuration';
 import { SignatureHelpProvider } from './providers/signatureHelpProvider';
 import { checkForRls, ensureToolchain, rustupUpdate } from './rustup';
@@ -29,6 +28,7 @@ import { startSpinner, stopSpinner } from './spinner';
 import { activateTaskProvider, Execution, runRlsCommand } from './tasks';
 import { withWsl } from './utils/child_process';
 import { uriWindowsToWsl, uriWslToWindows } from './utils/wslpath';
+import * as workspace_util from './workspace_util';
 
 /**
  * Parameter type to `window/progress` request as issued by the RLS.
@@ -72,12 +72,12 @@ function whenOpeningTextDocument(
   }
 
   const inMultiProjectMode = workspace
-      .getConfiguration()
-      .get<boolean>('rust-client.enableMultiProjectSetup', false);
+    .getConfiguration()
+    .get<boolean>('rust-client.enableMultiProjectSetup', false);
 
   const inNestedOuterProjectMode = workspace
-        .getConfiguration()
-        .get<boolean>('rust-client.nestedMultiRootConfigInOutermost', true);
+    .getConfiguration()
+    .get<boolean>('rust-client.nestedMultiRootConfigInOutermost', true);
 
   if (inMultiProjectMode) {
     folder = workspace_util.nearestParentWorkspace(folder, document.uri.fsPath);
@@ -124,7 +124,6 @@ function sortedWorkspaceFolders(): string[] {
   }
   return _sortedWorkspaceFolders || [];
 }
-
 
 function getOuterMostWorkspaceFolder(folder: WorkspaceFolder): WorkspaceFolder {
   // TODO: decouple the global state such that it can be moved to workspace_util

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,6 +108,7 @@ function whenOpeningTextDocument(
 let _sortedWorkspaceFolders: string[] | undefined;
 
 function sortedWorkspaceFolders(): string[] {
+  // TODO: decouple the global state such that it can be moved to workspace_util
   if (!_sortedWorkspaceFolders && workspace.workspaceFolders) {
     _sortedWorkspaceFolders = workspace.workspaceFolders
       .map(folder => {
@@ -126,6 +127,7 @@ function sortedWorkspaceFolders(): string[] {
 
 
 function getOuterMostWorkspaceFolder(folder: WorkspaceFolder): WorkspaceFolder {
+  // TODO: decouple the global state such that it can be moved to workspace_util
   const sorted = sortedWorkspaceFolders();
   for (const element of sorted) {
     let uri = folder.uri.toString();

--- a/src/workspace_util.ts
+++ b/src/workspace_util.ts
@@ -1,48 +1,42 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { WorkspaceFolder, Uri } from 'vscode';
-
-
+import { Uri, WorkspaceFolder } from 'vscode';
 
 // searches up the folder structure until it finds a Cargo.toml
 export function nearestParentWorkspace(
-    curWorkspace: WorkspaceFolder,
-    filePath: string,
-  ): WorkspaceFolder {
-
-    // check that the workspace folder already contains the "Cargo.toml"
-    const workspaceRoot = path.parse(curWorkspace.uri.fsPath).dir;
-    const rootManifest = path.join(workspaceRoot, 'Cargo.toml');
-    if (fs.existsSync(rootManifest)) {
-      return curWorkspace;
-    }
-
-    // algorithm that will strip one folder at a time and check if that folder contains "Cargo.toml"
-    let current = filePath;
-    while (true) {
-      const old = current;
-      current = path.dirname(current);
-
-      // break in case there is a bug that could result in a busy loop
-      if (old === current) {
-        break;
-      }
-
-      // break in case the strip folder has not changed
-      if (workspaceRoot === path.parse(current).dir) {
-        break;
-      }
-
-      // check if "Cargo.toml" is present in the parent folder
-      const cargoPath = path.join(current, 'Cargo.toml');
-      if (fs.existsSync(cargoPath)) {
-
-        // ghetto change the uri on Workspace folder to make vscode think it's located elsewhere
-        return { ...curWorkspace, uri: Uri.parse(current) };
-      }
-    }
-
+  curWorkspace: WorkspaceFolder,
+  filePath: string,
+): WorkspaceFolder {
+  // check that the workspace folder already contains the "Cargo.toml"
+  const workspaceRoot = path.parse(curWorkspace.uri.fsPath).dir;
+  const rootManifest = path.join(workspaceRoot, 'Cargo.toml');
+  if (fs.existsSync(rootManifest)) {
     return curWorkspace;
   }
 
+  // algorithm that will strip one folder at a time and check if that folder contains "Cargo.toml"
+  let current = filePath;
+  while (true) {
+    const old = current;
+    current = path.dirname(current);
 
+    // break in case there is a bug that could result in a busy loop
+    if (old === current) {
+      break;
+    }
+
+    // break in case the strip folder has not changed
+    if (workspaceRoot === path.parse(current).dir) {
+      break;
+    }
+
+    // check if "Cargo.toml" is present in the parent folder
+    const cargoPath = path.join(current, 'Cargo.toml');
+    if (fs.existsSync(cargoPath)) {
+      // ghetto change the uri on Workspace folder to make vscode think it's located elsewhere
+      return { ...curWorkspace, uri: Uri.parse(current) };
+    }
+  }
+
+  return curWorkspace;
+}

--- a/src/workspace_util.ts
+++ b/src/workspace_util.ts
@@ -10,11 +10,6 @@ export function nearestParentWorkspace(
     filePath: string,
   ): WorkspaceFolder {
 
-
-    if (!curWorkspace) {
-      return curWorkspace;
-    }
-
     const workspaceRoot = path.parse(curWorkspace.uri.fsPath).dir;
     const rootManifest = path.join(workspaceRoot, 'Cargo.toml');
     if (fs.existsSync(rootManifest)) {

--- a/src/workspace_util.ts
+++ b/src/workspace_util.ts
@@ -1,0 +1,45 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { WorkspaceFolder, Uri } from 'vscode';
+
+
+
+// searches up the folder structure until it finds a Cargo.toml
+export function nearestParentWorkspace(
+    curWorkspace: WorkspaceFolder,
+    filePath: string,
+  ): WorkspaceFolder {
+
+
+    if (!curWorkspace) {
+      return curWorkspace;
+    }
+
+    const workspaceRoot = path.parse(curWorkspace.uri.fsPath).dir;
+    const rootManifest = path.join(workspaceRoot, 'Cargo.toml');
+    if (fs.existsSync(rootManifest)) {
+      return curWorkspace;
+    }
+
+    let current = filePath;
+
+    while (true) {
+      const old = current;
+      current = path.dirname(current);
+      if (old === current) {
+        break;
+      }
+      if (workspaceRoot === path.parse(current).dir) {
+        break;
+      }
+
+      const cargoPath = path.join(current, 'Cargo.toml');
+      if (fs.existsSync(cargoPath)) {
+        return { ...curWorkspace, uri: Uri.parse(current) };
+      }
+    }
+
+    return curWorkspace;
+  }
+
+

--- a/src/workspace_util.ts
+++ b/src/workspace_util.ts
@@ -10,26 +10,34 @@ export function nearestParentWorkspace(
     filePath: string,
   ): WorkspaceFolder {
 
+    // check that the workspace folder already contains the "Cargo.toml"
     const workspaceRoot = path.parse(curWorkspace.uri.fsPath).dir;
     const rootManifest = path.join(workspaceRoot, 'Cargo.toml');
     if (fs.existsSync(rootManifest)) {
       return curWorkspace;
     }
 
+    // algorithm that will strip one folder at a time and check if that folder contains "Cargo.toml"
     let current = filePath;
-
     while (true) {
       const old = current;
       current = path.dirname(current);
+
+      // break in case there is a bug that could result in a busy loop
       if (old === current) {
         break;
       }
+
+      // break in case the strip folder has not changed
       if (workspaceRoot === path.parse(current).dir) {
         break;
       }
 
+      // check if "Cargo.toml" is present in the parent folder
       const cargoPath = path.join(current, 'Cargo.toml');
       if (fs.existsSync(cargoPath)) {
+
+        // ghetto change the uri on Workspace folder to make vscode think it's located elsewhere
         return { ...curWorkspace, uri: Uri.parse(current) };
       }
     }


### PR DESCRIPTION
This will allow you to have project structures like this:
```
projectA/Cargo.toml
projectA/src
projectB/Cargo.toml
projectB/src
subProjects/projectD/Cargo.toml
subProjects/projectD/src
subProjects/projectE/Cargo.toml
subProjects/projectE/src
```

when you open a file it will search up parent folders until it finds a Cargo.toml, and either reuse the RLS instance for that one or create one if it doesn't exists.


Changes
* enable multiple projects with multiple rls running
* change the `URI` key back to `string` for` workspaces` (as it's unreliable)
* add selectors such that only the correct rls is used for a given project
* take great care to ensure the old setup works as normal
* add a configuration and turn it off by default.

Second attempt at: #457