### PR TITLE
Add check to allow Windows users to select GNU/MSVC toolchain

### DIFF
--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -86,7 +86,13 @@ async function hasToolchain(config: RustupConfig): Promise<boolean> {
     const { stdout } = await withWsl(config.useWSL).exec(
       `${config.path} toolchain list`,
     );
-    return stdout.includes(config.channel);
+    if (/[a-z]+-(gnu|msvc)/.test(config.channel)) {
+      const dashIdx = config.channel.indexOf('-');
+      const toolchainRegex = new RegExp(config.channel.substr(0, dashIdx) + "-\\w+-\\w+-\\w+-" + config.channel.substr(dashIdx + 1), "g");
+      return toolchainRegex.test(stdout);
+    } else {
+      return stdout.includes(config.channel);
+    }
   } catch (e) {
     console.log(e);
     const rustupFoundButNotInWSLMode =

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -88,7 +88,12 @@ async function hasToolchain(config: RustupConfig): Promise<boolean> {
     );
     if (/[a-z]+-(gnu|msvc)/.test(config.channel)) {
       const dashIdx = config.channel.indexOf('-');
-      const toolchainRegex = new RegExp(config.channel.substr(0, dashIdx) + "-\\w+-\\w+-\\w+-" + config.channel.substr(dashIdx + 1), "g");
+      const toolchainRegex = new RegExp(
+        config.channel.substr(0, dashIdx) +
+          '-\\w+-\\w+-\\w+-' +
+          config.channel.substr(dashIdx + 1),
+        'g',
+      );
       return toolchainRegex.test(stdout);
     } else {
       return stdout.includes(config.channel);


### PR DESCRIPTION
In its current state, the extension does not properly check the output of the toolchain list command, thus causing the check to fail if a user specifies `<channel>-gnu` or `<channel>-msvc`. This patch detects the `-gnu` or `-msvc` suffix and updates the check accordingly. This probably isn't the best way to implement it, so feedback is appreciated.