### PR TITLE
Add rust.crate_blacklist entry to the package configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,6 +300,15 @@
                     "description": "Don't index crates on the crate blacklist.",
                     "scope": "resource"
                 },
+                "rust.crate_blacklist": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "default": null,
+                    "description": "Overrides the default list of packages for which analysis is skipped.\nAvailable since RLS 1.38",
+                    "scope": "resource"
+                },
                 "rust.build_on_save": {
                     "type": "boolean",
                     "default": false,

--- a/package.json
+++ b/package.json
@@ -298,7 +298,8 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Don't index crates on the crate blacklist.",
-                    "scope": "resource"
+                    "scope": "resource",
+                    "deprecationMessage": "Use `rust.crate_blacklist` instead"
                 },
                 "rust.crate_blacklist": {
                     "type": [


### PR DESCRIPTION
This also deprecates `rust.use_crate_blacklist`, however the replacement is only available on the current nightly so we make sure to mention that in case a stable user tries to immediately switch over.