### PR TITLE
Fix rust-client.channel.type

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
                 "rust-client.channel": {
                     "type": [
                         "string",
-                        null
+                        "null"
                     ],
                     "enum": [
                         "stable",


### PR DESCRIPTION
This PR fixes the type of the `rust-client.channel` config property. 

`null` value leads to invalid schema. Ajv is failing to compile it:
```
schema is invalid: data.properties['rust-client.channel'].type should be equal to one of the allowed values, data.properties['rust-client.channel'].type[1] should be equal to one of the allowed values, data.properties['rust-client.channel'].type should match some schema in anyOf
```