### PR TITLE
Remove "null" from type field in config of crate_blacklist

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,10 +302,7 @@
                     "deprecationMessage": "Use `rust.crate_blacklist` instead"
                 },
                 "rust.crate_blacklist": {
-                    "type": [
-                        "array",
-                        "null"
-                    ],
+                    "type": "array",
                     "default": [
                         "cocoa",
                         "gleam",


### PR DESCRIPTION
For issue #656 
I tryed to remove suspicious default value of "null" from type field in `crate_blacklist`

But I could not  test it on my laptop. I tryed to follow the instruction of `contributing.md`, but I can not understand it.
So could you test this PR? or tell me something simple process of test ( sorry )  ?