### PR TITLE
Add command for creating a new Cargo project

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     ],
     "preview": true,
     "activationEvents": [
+        "onCommand:cargo.new",
         "onLanguage:rust",
         "workspaceContains:Cargo.toml"
     ],
@@ -83,6 +84,12 @@
             }
         ],
         "commands": [
+            {
+                "command": "cargo.new",
+                "title": "Create new Cargo project",
+                "description": "Use `cargo new` to create a new Rust project",
+                "category": "Rust"
+            },
             {
                 "command": "rls.update",
                 "title": "Update the RLS",


### PR DESCRIPTION
This PR adds a new command which asks the user for some details then creates a new crate using `cargo new`.

Fixes #254.

To do:
- [ ] Move the `createNewProject` command implementation somewhere else. 
- [ ] Add tests. I'm not familiar with VS Code extension development so I don't exactly know how this would be implemented.