### PR TITLE
change default `wait_to_build` to 300 ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -289,7 +289,7 @@
                 },
                 "rust.wait_to_build": {
                     "type": "number",
-                    "default": 1500,
+                    "default": 300,
                     "description": "Time in milliseconds between receiving a change notification and starting build.",
                     "scope": "resource"
                 },


### PR DESCRIPTION
This changes the default `rust.wait_to_build` time to 300 ms.
When doing changes in Rust source files, smaller times to build makes the overall
editing-experience much better, because the developer gets faster feedback.

Is there a reason, why this value was at 1500 ms (which is pretty high IMO)?

I'd really like to see this PR merged, because I always thought that it is the RLS or Rustc itself, which is slow, but it was just due to this setting.

Thanks!

Related: #604