### PR TITLE
Use dynamic wait_to_build inferred by the RLS by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Use dynamic `wait_to_build` in RLS by default rather than setting it to 1500ms
+
 ### 0.7.0 - 2019-10-15
 
 * Implement support for multi-project workspace layout 🎉

--- a/package.json
+++ b/package.json
@@ -288,8 +288,11 @@
                     "scope": "resource"
                 },
                 "rust.wait_to_build": {
-                    "type": "number",
-                    "default": 1500,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "default": null,
                     "description": "Time in milliseconds between receiving a change notification and starting build.",
                     "scope": "resource"
                 },


### PR DESCRIPTION
That was an oversight when we implemented dynamic `wait_to_build` on the RLS side - we forgot to update the default on the VSCode side. This substantially reduces the default latency on small-medium projects.

cc @alexheretic @janriemer
Closes #670 