### PR TITLE
Update prefix on spawn snippet

### DIFF
--- a/snippets/rust.json
+++ b/snippets/rust.json
@@ -78,7 +78,10 @@
         "description": "Unwrap Option with if let"
     },
     "spawn": {
-        "prefix": "thread::spawn",
+        "prefix": [
+            "thread_spawn",
+            "spawn"
+        ],
         "body": [
             "thread::spawn(move || {",
             "\t$0",


### PR DESCRIPTION
Closes #669 

As already described in #669, the `thread::spawn` snippet gets triggered every time the `:` symbol is typed into the editor, which causes an unnecessary pollution in the autocomplete suggestions list, and can be quite annoying when dealing with things like: enums (to access its variants), modules (to access its definitions), structs (to call associated functions on it), "imports" on nested paths, etc. In general, anything that requires writing `::`, since as soon as the first `:` is typed, the suggestion for the `thread::spawn` snippet is retrieved.

In order to fix the aforementioned issue, I've updated the prefix `thread::spawn` to `thread_spawn` and `spawn`.

**Note**: Thanks for the great work you've done on this tool, I've been REALLY loving and enjoying learning rust using VSCode using this awesome integration of the RLS. Thanks again 🏅 