### PR TITLE
Specify Default Toolchain as Active Channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
                         "null"
                     ],
                     "enum": [
+                        "default",
                         "stable",
                         "beta",
                         "nightly"

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -62,7 +62,7 @@ export class RLSConfiguration {
     configuration: WorkspaceConfiguration,
   ): string {
     const channel = configuration.get<string>('rust-client.channel');
-    if(channel === 'default' || !channel) {
+    if (channel === 'default' || !channel) {
       try {
         return getActiveChannel(wsPath, rustupConfiguration);
       } catch (e) {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -62,16 +62,25 @@ export class RLSConfiguration {
     configuration: WorkspaceConfiguration,
   ): string {
     const channel = configuration.get<string>('rust-client.channel');
-    if (channel) {
+    if(channel && channel === "default") {
+      return RLSConfiguration.defaultOrNightly(wsPath, rustupConfiguration);
+    } else if(channel) {
       return channel;
     } else {
-      try {
-        return getActiveChannel(wsPath, rustupConfiguration);
-      } catch (e) {
-        // rustup might not be installed at the time the configuration is
-        // initially loaded, so silently ignore the error and return a default value
-        return 'nightly';
-      }
+      return RLSConfiguration.defaultOrNightly(wsPath, rustupConfiguration);
+    }
+  }
+  
+  private static defaultOrNightly(
+    wsPath: string,
+    rustupConfiguration: RustupConfig,
+  ): string {
+    try {
+      return getActiveChannel(wsPath, rustupConfiguration);
+    } catch (e) {
+      // rustup might not be installed at the time the configuration is
+      // initially loaded, so silently ignore the error and return a default value
+      return 'nightly';
     }
   }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -62,25 +62,16 @@ export class RLSConfiguration {
     configuration: WorkspaceConfiguration,
   ): string {
     const channel = configuration.get<string>('rust-client.channel');
-    if(channel && channel === "default") {
-      return RLSConfiguration.defaultOrNightly(wsPath, rustupConfiguration);
-    } else if(channel) {
-      return channel;
+    if(channel === 'default' || !channel) {
+      try {
+        return getActiveChannel(wsPath, rustupConfiguration);
+      } catch (e) {
+        // rustup might not be installed at the time the configuration is
+        // initially loaded, so silently ignore the error and return a default value
+        return 'nightly';
+      }
     } else {
-      return RLSConfiguration.defaultOrNightly(wsPath, rustupConfiguration);
-    }
-  }
-  
-  private static defaultOrNightly(
-    wsPath: string,
-    rustupConfiguration: RustupConfig,
-  ): string {
-    try {
-      return getActiveChannel(wsPath, rustupConfiguration);
-    } catch (e) {
-      // rustup might not be installed at the time the configuration is
-      // initially loaded, so silently ignore the error and return a default value
-      return 'nightly';
+      return channel;
     }
   }
 

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -274,7 +274,7 @@ export function getActiveChannel(wsPath: string, config: RustupConfig): string {
   }
 
   console.info(
-    `Detected active channel: ${activeChannel} (since 'rust-client.channel' is unspecified)`,
+    `Using active channel: ${activeChannel}`,
   );
   return activeChannel;
 }

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -273,8 +273,6 @@ export function getActiveChannel(wsPath: string, config: RustupConfig): string {
     activeChannel = parseActiveToolchain(showOutput);
   }
 
-  console.info(
-    `Using active channel: ${activeChannel}`,
-  );
+  console.info(`Using active channel: ${activeChannel}`);
   return activeChannel;
 }


### PR DESCRIPTION
This patch enables the user to opt for the default toolchain in addition to stable, beta, or nightly. The default toolchain is currently only used as a fallback if the channel value is not present. The same effect could be achieved by deleting the settings.json entry, however I actually didn't figure that out until after perusing the source seeing how it's implemented. I think it would be helpful to be able to explicitly specify to use the default toolchain.

**Context**
I'm a new Rustacean and ran into the first occasion where I wanted to use a nightly feature. I had previously explicitly set the stable channel  when I first set the extension up in VS Code. When RLS complained about my nightly feature flag in my source, I popped over to the settings UI and switched the channel to nightly where it then complained that RLS wasn't available after trying to install it from the unstable channel. That led me into finding out that RLS isn't available in all versions of nightly Rust, so I installed an older nightly toolchain where RLS was available. I had expected this to work, but it still complained, and that's when I figured out the extension is using the nightly channel and not the nightly toolchain that was set as default. Even reading the text "By default, uses the same channel as your currently open project" it didn't really click to edit the settings.json file. I use VS Code as my daily driver for most of my coding and I constantly forget that the settings are backed by a json file when I'm twiddling with settings and it's not actually apparent through the UI that the stable channel isn't the default since it's the one showing up in the drop box by default.