### PR TITLE
Add angular brackets to `autoClosingPairs`

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -13,6 +13,7 @@
        { "open": "{", "close": "}" },
        { "open": "[", "close": "]" },
        { "open": "(", "close": ")" },
+       { "open": "<", "close": ">" },
        { "open": "\"", "close": "\"", "notIn": ["string"] },
        { "open": "/**", "close": " */", "notIn": ["string"] },
        { "open": "/*!", "close": " */", "notIn": ["string"] }


### PR DESCRIPTION
I am currently switching from github's [atom](https://atom.io/) editor to vscode and one thing, that I immediately noticed, was that, when you type `<` there will no `>` added automatically, like it is done with `{` and `}`. At first, I suspected, that this was a global setting, but after a bit more testing and a post on [`r/vscode`](https://www.reddit.com/r/vscode/comments/ednx1l/is_it_possible_to_automatically_add_a_closing/) I found out, that this seems to be an issue with the language extension.

### Open questions
Should this be a separate setting for the language extension? If so how do I make this a setting? (I never did anything with vscode extensions)

fixes #719 