### PR TITLE
Fix vulnerable dev dependency and add audit build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,4 @@ script:
   - npm run compile
   - npm run lint
   - npm run test
+  - npm audit

--- a/package-lock.json
+++ b/package-lock.json
@@ -587,12 +587,12 @@
             }
         },
         "https-proxy-agent": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-            "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+            "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
             "dev": true,
             "requires": {
-                "agent-base": "^4.1.0",
+                "agent-base": "^4.3.0",
                 "debug": "^3.1.0"
             }
         },


### PR DESCRIPTION
closes #724

This PR fixes a vulnerable dev dependency of `vscode-test` > `https-proxy-agent` (see https://www.npmjs.com/advisories/1184) by running `npm audit fix`.

This also adds `npm audit` as a build step in CI to check for vulnerabilities on each PR, and to ensure that changes don't add already vulnerable packages.