### PR TITLE
Fix workspace path when multiProjectSetup is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
                 "rust-client.enableMultiProjectSetup": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Allow multiple projects in the same folder, along with remove the constraint that the cargo.toml must be located at the root. (Experimental: might not work for certain setups)"
+                    "description": "Allow multiple projects in the same folder, along with removing the constraint that the cargo.toml must be located at the root. (Experimental: might not work for certain setups)"
                 },
                 "rust.sysroot": {
                     "type": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -310,6 +310,7 @@ class ClientWorkspace {
       const ws =
         multiProjectEnabled && activeWorkspace ? activeWorkspace : this;
       await ws.stop();
+      commandsRegistered = true;
       return ws.start(context);
     });
     this.disposables.push(restartServer);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -208,7 +208,7 @@ class ClientWorkspace {
     };
 
     const pattern = this.config.multiProjectEnabled
-      ? `${this.folder.uri.path}/**`
+      ? `**${this.folder.uri.path}/**`
       : undefined;
     const collectionName = this.config.multiProjectEnabled
       ? `rust ${this.folder.uri.toString()}`

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -207,8 +207,14 @@ class ClientWorkspace {
       return this.makeRlsProcess();
     };
 
+    // Something else is put front of files when pattern matching that prevents the windows version from picking up the files
+    // This should be safe as the uri is a absolute path that includes the drive + colon
+    // i.e. a pattern would become "**/c:/some/path**" and since colon is reserved only the root can ever contain it.
+    const isWin = process.platform === 'win32';
+    const windowsHack = isWin ? '**' : '';
+
     const pattern = this.config.multiProjectEnabled
-      ? `**${this.folder.uri.path}/**`
+      ? `${windowsHack}${this.folder.uri.path}/**`
       : undefined;
 
     const collectionName = this.config.multiProjectEnabled

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -210,8 +210,9 @@ class ClientWorkspace {
     const pattern = this.config.multiProjectEnabled
       ? `**${this.folder.uri.path}/**`
       : undefined;
+
     const collectionName = this.config.multiProjectEnabled
-      ? `rust ${this.folder.uri.toString()}`
+      ? `rust ${this.folder.uri.path}`
       : 'rust';
     const clientOptions: LanguageClientOptions = {
       // Register the server for Rust files

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -212,7 +212,7 @@ class ClientWorkspace {
       : undefined;
 
     const collectionName = this.config.multiProjectEnabled
-      ? `rust ${this.folder.uri.path}`
+      ? `rust ${this.folder.uri.toString()}`
       : 'rust';
     const clientOptions: LanguageClientOptions = {
       // Register the server for Rust files

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -78,7 +78,7 @@ function detectCargoTasks(target: WorkspaceFolder): Task[] {
     .map(({ subcommand, group }) => ({
       definition: { subcommand, type: TASK_TYPE },
       label: `cargo ${subcommand}`,
-      execution: createShellExecution({ command: 'cargo', args: [subcommand] }),
+      execution: createShellExecution({ command: 'cargo', args: [subcommand], cwd: target.uri.fsPath }),
       group,
       problemMatchers: ['$rustc'],
     }))

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -78,7 +78,11 @@ function detectCargoTasks(target: WorkspaceFolder): Task[] {
     .map(({ subcommand, group }) => ({
       definition: { subcommand, type: TASK_TYPE },
       label: `cargo ${subcommand}`,
-      execution: createShellExecution({ command: 'cargo', args: [subcommand], cwd: target.uri.fsPath }),
+      execution: createShellExecution({
+        command: 'cargo',
+        args: [subcommand],
+        cwd: target.uri.fsPath,
+      }),
       group,
       problemMatchers: ['$rustc'],
     }))

--- a/src/workspace_util.ts
+++ b/src/workspace_util.ts
@@ -8,7 +8,7 @@ export function nearestParentWorkspace(
   filePath: string,
 ): WorkspaceFolder {
   // check that the workspace folder already contains the "Cargo.toml"
-  const workspaceRoot = path.parse(curWorkspace.uri.fsPath).dir;
+  const workspaceRoot = curWorkspace.uri.fsPath;
   const rootManifest = path.join(workspaceRoot, 'Cargo.toml');
   if (fs.existsSync(rootManifest)) {
     return curWorkspace;

--- a/src/workspace_util.ts
+++ b/src/workspace_util.ts
@@ -34,7 +34,7 @@ export function nearestParentWorkspace(
     const cargoPath = path.join(current, 'Cargo.toml');
     if (fs.existsSync(cargoPath)) {
       // ghetto change the uri on Workspace folder to make vscode think it's located elsewhere
-      return { ...curWorkspace, uri: Uri.parse(current) };
+      return { ...curWorkspace, uri: Uri.file(current) };
     }
   }
 

--- a/src/workspace_util.ts
+++ b/src/workspace_util.ts
@@ -25,8 +25,8 @@ export function nearestParentWorkspace(
       break;
     }
 
-    // break in case the strip folder has not changed
-    if (workspaceRoot === path.parse(current).dir) {
+    // break in case the strip folder reached the workspace root
+    if (workspaceRoot === current) {
       break;
     }
 

--- a/src/workspace_util.ts
+++ b/src/workspace_util.ts
@@ -34,7 +34,11 @@ export function nearestParentWorkspace(
     const cargoPath = path.join(current, 'Cargo.toml');
     if (fs.existsSync(cargoPath)) {
       // ghetto change the uri on Workspace folder to make vscode think it's located elsewhere
-      return { ...curWorkspace, name: path.basename(current), uri: Uri.file(current) };
+      return {
+        ...curWorkspace,
+        name: path.basename(current),
+        uri: Uri.file(current),
+      };
     }
   }
 

--- a/src/workspace_util.ts
+++ b/src/workspace_util.ts
@@ -34,7 +34,7 @@ export function nearestParentWorkspace(
     const cargoPath = path.join(current, 'Cargo.toml');
     if (fs.existsSync(cargoPath)) {
       // ghetto change the uri on Workspace folder to make vscode think it's located elsewhere
-      return { ...curWorkspace, uri: Uri.file(current) };
+      return { ...curWorkspace, name: path.basename(current), uri: Uri.file(current) };
     }
   }
 


### PR DESCRIPTION
When `enableMultiProjectSetup=true` the following bugs will be fixed

* Fix a minor bug where workspace folder was stripped from short-circuit check
* Use correct pathing format (Fixes pathing for windows)
* Fix document selector for windows. (windows wouldn't trigger rls hover/actions)
* Fix `cargo build` as it would previously point to the root folder (pointed out by @jli in #419).

The branch has been tested on *windows 10* & *ubuntu 18.04*

Will fix #713 
