### PR TITLE
Fix support for multiple VSCode workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Fix support for multiple VSCode workspaces
+
 ### 0.7.2 - 2020-04-17
 
 * Fix a bug where rustup didn't install all of the required components for the RLS

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -171,24 +171,6 @@ function whenChangingWorkspaceFolders(e: WorkspaceFoldersChangeEvent) {
 
 // Don't use URI as it's unreliable the same path might not become the same URI.
 const workspaces: Map<string, ClientWorkspace> = new Map();
-let activeWorkspace: ClientWorkspace | null;
-
-function registerCommands(): Disposable[] {
-  return [
-    commands.registerCommand(
-      'rls.update',
-      () => activeWorkspace && activeWorkspace.rustupUpdate(),
-    ),
-    commands.registerCommand(
-      'rls.restart',
-      async () => activeWorkspace && activeWorkspace.restart(),
-    ),
-    commands.registerCommand(
-      'rls.run',
-      (cmd: Execution) => activeWorkspace && activeWorkspace.runRlsCommand(cmd),
-    ),
-  ];
-}
 
 // We run one RLS and one corresponding language client per workspace folder
 // (VSCode workspace, not Cargo workspace). This class contains all the per-client
@@ -480,6 +462,34 @@ async function warnOnMissingCargoToml() {
       'A Cargo.toml file must be at the root of the workspace in order to support all features. Alternatively set rust-client.enableMultiProjectSetup=true in settings.',
     );
   }
+}
+
+/**
+ * Tracks the most current VSCode workspace as opened by the user. Used by the
+ * commands to know in which workspace these should be executed.
+ */
+let activeWorkspace: ClientWorkspace | null;
+
+/**
+ * Registers the VSCode [commands] used by the extension.
+ *
+ * [commands]: https://code.visualstudio.com/api/extension-guides/command
+ */
+function registerCommands(): Disposable[] {
+  return [
+    commands.registerCommand(
+      'rls.update',
+      () => activeWorkspace && activeWorkspace.rustupUpdate(),
+    ),
+    commands.registerCommand(
+      'rls.restart',
+      async () => activeWorkspace && activeWorkspace.restart(),
+    ),
+    commands.registerCommand(
+      'rls.run',
+      (cmd: Execution) => activeWorkspace && activeWorkspace.runRlsCommand(cmd),
+    ),
+  ];
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -209,13 +209,9 @@ class ClientWorkspace {
     const isWin = process.platform === 'win32';
     const windowsHack = isWin ? '**' : '';
 
-    const pattern = this.config.multiProjectEnabled
-      ? `${windowsHack}${this.folder.uri.path}/**`
-      : undefined;
+    const pattern = `${windowsHack}${this.folder.uri.path}/**`;
 
-    const collectionName = this.config.multiProjectEnabled
-      ? `rust ${this.folder.uri.toString()}`
-      : 'rust';
+    const collectionName = `rust (${this.folder.uri.toString()})`;
     const clientOptions: LanguageClientOptions = {
       // Register the server for Rust files
 
@@ -259,9 +255,7 @@ class ClientWorkspace {
       clientOptions,
     );
 
-    const selector = this.config.multiProjectEnabled
-      ? { language: 'rust', scheme: 'file', pattern }
-      : { language: 'rust' };
+    const selector = { language: 'rust', scheme: 'file', pattern };
 
     this.setupProgressCounter();
     this.disposables.push(activateTaskProvider(this.folder));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,11 +47,13 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(...registerCommands());
 
   workspace.onDidOpenTextDocument(doc => whenOpeningTextDocument(doc));
-  workspace.textDocuments.forEach(doc => whenOpeningTextDocument(doc));
   workspace.onDidChangeWorkspaceFolders(e => whenChangingWorkspaceFolders(e));
   window.onDidChangeActiveTextEditor(
     ed => ed && whenOpeningTextDocument(ed.document),
   );
+  // Installed listeners don't fire immediately for already opened files, so
+  // trigger an open event manually to fire up RLS instances where needed
+  workspace.textDocuments.forEach(whenOpeningTextDocument);
 }
 
 export async function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,8 +44,7 @@ interface ProgressParams {
 
 export async function activate(context: ExtensionContext) {
   context.subscriptions.push(configureLanguage());
-
-  registerCommands();
+  context.subscriptions.push(...registerCommands());
 
   workspace.onDidOpenTextDocument(doc => whenOpeningTextDocument(doc));
   workspace.textDocuments.forEach(doc => whenOpeningTextDocument(doc));
@@ -56,7 +55,6 @@ export async function activate(context: ExtensionContext) {
 }
 
 export async function deactivate() {
-  [...cmds.values()].forEach(c => c.dispose());
   return Promise.all([...workspaces.values()].map(ws => ws.stop()));
 }
 
@@ -175,29 +173,21 @@ function whenChangingWorkspaceFolders(e: WorkspaceFoldersChangeEvent) {
 const workspaces: Map<string, ClientWorkspace> = new Map();
 let activeWorkspace: ClientWorkspace | null;
 
-const cmds: Set<Disposable> = new Set();
-
-function registerCommands() {
-  cmds.add(
+function registerCommands(): Disposable[] {
+  return [
     commands.registerCommand(
       'rls.update',
       () => activeWorkspace && activeWorkspace.rustupUpdate(),
     ),
-  );
-
-  cmds.add(
     commands.registerCommand(
       'rls.restart',
       async () => activeWorkspace && activeWorkspace.restart(),
     ),
-  );
-
-  cmds.add(
     commands.registerCommand(
       'rls.run',
       (cmd: Execution) => activeWorkspace && activeWorkspace.runRlsCommand(cmd),
     ),
-  );
+  ];
 }
 
 // We run one RLS and one corresponding language client per workspace folder

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -76,7 +76,7 @@ function detectCargoTasks(target: WorkspaceFolder): Task[] {
   ]
     .map(({ subcommand, group }) => ({
       definition: { subcommand, type: TASK_TYPE },
-      label: `cargo ${subcommand}`,
+      label: `cargo ${subcommand} - ${target.name}`,
       execution: createShellExecution({
         command: 'cargo',
         args: [subcommand],


### PR DESCRIPTION
Closes #601.

This is based on #601 (thanks @zkat!) and extended a bit to fix our integration with custom signature helper.

The gist is of it is to globally register the commands so there are no more exceptions once we try to spin up another instance, which prevented us from doing so, earlier.

The fix for signature helper means we have to drop some checks for `multiProjectEnabled` and unconditionally use the logic as if the config was turned on, which leaves me wondering if we should just enable it unconditionally...

Tested and it seems to be working both for multiple VSCode workspaces and it didn't regress the multiple projects per a single workspace.

@zkat @jannickj do you mind taking a look at this?