### PR TITLE
Refactor workspace handling 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 .vscode-test
 *.vsix
+rls*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Ignore setting `rust-client.enableMultiProjectSetup` (it's always on by default)
 * Fix support for multiple VSCode workspaces
 
 ### 0.7.2 - 2020-04-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Remove redundant `rust-client.nestedMultiRootConfigInOutermost` setting (originally used to work around non-multi-project limitations)
 * Ignore setting `rust-client.enableMultiProjectSetup` (it's always on by default)
 * Fix support for multiple VSCode workspaces
 

--- a/fixtures/another-lib-project/Cargo.toml
+++ b/fixtures/another-lib-project/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "bare-lib-project"
+version = "0.1.0"
+authors = ["Example <example@example.com>"]
+edition = "2018"
+
+[dependencies]

--- a/fixtures/another-lib-project/src/lib.rs
+++ b/fixtures/another-lib-project/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -227,11 +227,6 @@
                     "description": "Traces the communication between VS Code and the Rust language server.",
                     "scope": "window"
                 },
-                "rust-client.nestedMultiRootConfigInOutermost": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "If one root workspace folder is nested in another root folder, look for the Rust config in the outermost root."
-                },
                 "rust-client.enableMultiProjectSetup": {
                     "type": ["boolean", "null"],
                     "default": null,

--- a/package.json
+++ b/package.json
@@ -233,8 +233,8 @@
                     "description": "If one root workspace folder is nested in another root folder, look for the Rust config in the outermost root."
                 },
                 "rust-client.enableMultiProjectSetup": {
-                    "type": "boolean",
-                    "default": false,
+                    "type": ["boolean", "null"],
+                    "default": null,
                     "description": "Allow multiple projects in the same folder, along with removing the constraint that the cargo.toml must be located at the root. (Experimental: might not work for certain setups)"
                 },
                 "rust.sysroot": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -118,13 +118,6 @@ export class RLSConfiguration {
     return this.configuration.get<string>('rust-client.rlsPath');
   }
 
-  public get multiProjectEnabled(): boolean {
-    return this.configuration.get<boolean>(
-      'rust-client.enableMultiProjectSetup',
-      false,
-    );
-  }
-
   // Added ignoreChannel for readChannel function. Otherwise we end in an infinite loop.
   public rustupConfig(ignoreChannel: boolean = false): RustupConfig {
     return {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,22 +98,12 @@ function whenOpeningTextDocument(document: TextDocument) {
     return;
   }
 
-  const uri = document.uri;
-  let folder = workspace.getWorkspaceFolder(uri);
+  let folder = workspace.getWorkspaceFolder(document.uri);
   if (!folder) {
     return;
   }
 
-  const inMultiProjectMode = true;
-  const inNestedOuterProjectMode = workspace
-    .getConfiguration()
-    .get<boolean>('rust-client.nestedMultiRootConfigInOutermost', true);
-
-  if (inMultiProjectMode) {
-    folder = nearestParentWorkspace(folder, document.uri.fsPath);
-  } else if (inNestedOuterProjectMode) {
-    folder = getOuterMostWorkspaceFolder(folder);
-  }
+  folder = nearestParentWorkspace(folder, document.uri.fsPath);
 
   if (!folder) {
     stopSpinner(`RLS: Cargo.toml missing`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,7 +112,7 @@ function whenChangingWorkspaceFolders(e: WorkspaceFoldersChangeEvent) {
   // If a VSCode workspace has been added, check to see if it is part of an existing one, and
   // if not, and it is a Rust project (i.e., has a Cargo.toml), then create a new client.
   for (let folder of e.added) {
-    folder = getOuterMostWorkspaceFolder(folder, { cached: false });
+    folder = getOuterMostWorkspaceFolder(folder);
     if (workspaces.has(folder.uri.toString())) {
       continue;
     }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -45,27 +45,16 @@ export function nearestParentWorkspace(
   return curWorkspace;
 }
 
-// This is an intermediate, lazy cache used by `getOuterMostWorkspaceFolder`
-// and should be regenerated when VSCode workspaces change.
-let _cachedSortedWorkspaceFolders: string[] | undefined;
-
 export function getOuterMostWorkspaceFolder(
   folder: WorkspaceFolder,
-  options?: { cached: boolean },
 ): WorkspaceFolder {
-  const recalculate = !options || !options.cached;
-  // Sort workspace folders or used already cached result, if possible
-  const sortedFolders =
-    !recalculate && _cachedSortedWorkspaceFolders
-      ? _cachedSortedWorkspaceFolders
-      : (workspace.workspaceFolders || [])
-          .map(folder => normalizeUriToPathPrefix(folder.uri))
-          .sort((a, b) => a.length - b.length);
-  _cachedSortedWorkspaceFolders = sortedFolders;
+  const sortedFoldersByPrefix = (workspace.workspaceFolders || [])
+    .map(folder => normalizeUriToPathPrefix(folder.uri))
+    .sort((a, b) => a.length - b.length);
 
   const uri = normalizeUriToPathPrefix(folder.uri);
 
-  const outermostPath = sortedFolders.find(prefix => uri.startsWith(prefix));
+  const outermostPath = sortedFoldersByPrefix.find(pre => uri.startsWith(pre));
   return outermostPath
     ? workspace.getWorkspaceFolder(Uri.parse(outermostPath)) || folder
     : folder;


### PR DESCRIPTION
This contains some QoL changes to workspace handling, namely we ~always spin up RLS instance in a freshly opened VSCode instance with Rust projects opened~ and we default all of our settings to enable the multi-project setup. Previously, the settings were introduced not to regress the main experience but time has come to provide support for multi-root workspaces by default.

EDIT: Don't always spin up the RLS instance for now, since perceived cost of RLS seems to be high and we probably shouldn't land this until some version of #682 lands first.