### PR TITLE
Progress tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Correctly run tasks based on active text editor rather than last opened Rust file
 * (!) Don't immediately try to start server instance for newly added workspace folders
 * Use smooth, universally supported spinner in the status bar ⚙️
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ### Unreleased
 
+* (!) Don't immediately start server instances for every already opened file
+* (!) Don't immediately start server instances for newly added workspace folders
 * Dynamically show progress only for the active client workspace
 * Correctly run tasks based on active text editor rather than last opened Rust file
-* (!) Don't immediately try to start server instance for newly added workspace folders
 * Use smooth, universally supported spinner in the status bar ⚙️
 
 ### 0.7.3 - 2020-04-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Dynamically show progress only for the active client workspace
 * Correctly run tasks based on active text editor rather than last opened Rust file
 * (!) Don't immediately try to start server instance for newly added workspace folders
 * Use smooth, universally supported spinner in the status bar ⚙️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* (!) Don't immediately try to start server instance for newly added workspace folders
 * Use smooth, universally supported spinner in the status bar ⚙️
 
 ### 0.7.3 - 2020-04-21

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,12 +46,16 @@ interface ProgressParams {
 }
 
 export async function activate(context: ExtensionContext) {
-  context.subscriptions.push(configureLanguage());
-  context.subscriptions.push(...registerCommands());
-
-  workspace.onDidChangeWorkspaceFolders(whenChangingWorkspaceFolders);
-  window.onDidChangeActiveTextEditor(onDidChangeActiveTextEditor);
-  // Trigger manually logic for opening the first active editor
+  context.subscriptions.push(
+    ...[
+      configureLanguage(),
+      ...registerCommands(),
+      workspace.onDidChangeWorkspaceFolders(whenChangingWorkspaceFolders),
+      window.onDidChangeActiveTextEditor(onDidChangeActiveTextEditor),
+    ],
+  );
+  // Manually trigger the first event to start up server instance if necessary,
+  // since VSCode doesn't do that on startup by itself.
   onDidChangeActiveTextEditor(window.activeTextEditor);
 
   // Migrate the users of multi-project setup for RLS to disable the setting

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,7 +52,7 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(...registerCommands());
 
   workspace.onDidOpenTextDocument(doc => whenOpeningTextDocument(doc));
-  workspace.onDidChangeWorkspaceFolders(e => whenChangingWorkspaceFolders(e));
+  workspace.onDidChangeWorkspaceFolders(whenChangingWorkspaceFolders);
   window.onDidChangeActiveTextEditor(
     ed => ed && whenOpeningTextDocument(ed.document),
   );
@@ -124,23 +124,6 @@ function whenOpeningTextDocument(document: TextDocument) {
 }
 
 function whenChangingWorkspaceFolders(e: WorkspaceFoldersChangeEvent) {
-  // If a VSCode workspace has been added, check to see if it is part of an existing one, and
-  // if not, and it is a Rust project (i.e., has a Cargo.toml), then create a new client.
-  for (let folder of e.added) {
-    folder = getOuterMostWorkspaceFolder(folder);
-    if (workspaces.has(folder.uri.toString())) {
-      continue;
-    }
-    for (const f of fs.readdirSync(folder.uri.fsPath)) {
-      if (f === 'Cargo.toml') {
-        const workspace = new ClientWorkspace(folder);
-        workspaces.set(folder.uri.toString(), workspace);
-        workspace.start();
-        break;
-      }
-    }
-  }
-
   // If a workspace is removed which is a Rust workspace, kill the client.
   for (const folder of e.removed) {
     const ws = workspaces.get(folder.uri.toString());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,7 +106,7 @@ function whenOpeningTextDocument(document: TextDocument) {
   folder = nearestParentWorkspace(folder, document.uri.fsPath);
 
   if (!folder) {
-    stopSpinner(`RLS: Cargo.toml missing`);
+    stopSpinner(`Cargo.toml missing`);
     return;
   }
 
@@ -172,7 +172,7 @@ class ClientWorkspace {
   }
 
   public async start() {
-    startSpinner('RLS', 'Starting');
+    startSpinner('Starting');
 
     const serverOptions: ServerOptions = async () => {
       await this.autoUpdate();
@@ -273,7 +273,7 @@ class ClientWorkspace {
 
     const runningProgress: Set<string> = new Set();
     await this.lc.onReady();
-    stopSpinner('RLS');
+    stopSpinner();
 
     this.lc.onNotification(
       new NotificationType<ProgressParams, void>('window/progress'),
@@ -292,9 +292,9 @@ class ClientWorkspace {
           } else if (progress.title) {
             status = `[${progress.title.toLowerCase()}]`;
           }
-          startSpinner('RLS', status);
+          startSpinner(status);
         } else {
-          stopSpinner('RLS');
+          stopSpinner();
         }
       },
     );

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -21,7 +21,7 @@ export interface RustupConfig {
 }
 
 export async function rustupUpdate(config: RustupConfig) {
-  startSpinner('RLS', 'Updating…');
+  startSpinner('Updating…');
 
   try {
     const { stdout } = await withWsl(config.useWSL).exec(
@@ -103,7 +103,7 @@ async function hasToolchain(config: RustupConfig): Promise<boolean> {
 }
 
 async function tryToInstallToolchain(config: RustupConfig) {
-  startSpinner('RLS', 'Installing toolchain…');
+  startSpinner('Installing toolchain…');
   try {
     const { command, args } = withWsl(config.useWSL).modifyArgs(config.path, [
       'toolchain',
@@ -154,7 +154,7 @@ async function hasRlsComponents(config: RustupConfig): Promise<boolean> {
 }
 
 async function installRlsComponents(config: RustupConfig) {
-  startSpinner('RLS', 'Installing components…');
+  startSpinner('Installing components…');
 
   for (const component of REQUIRED_COMPONENTS) {
     try {

--- a/src/spinner.ts
+++ b/src/spinner.ts
@@ -1,9 +1,9 @@
 import { window } from 'vscode';
 
-export function startSpinner(prefix: string, postfix: string) {
-  window.setStatusBarMessage(`${prefix} $(settings-gear~spin) ${postfix}`);
+export function startSpinner(message: string) {
+  window.setStatusBarMessage(`RLS $(settings-gear~spin) ${message}`);
 }
 
-export function stopSpinner(message: string) {
-  window.setStatusBarMessage(message);
+export function stopSpinner(message?: string) {
+  window.setStatusBarMessage(`RLS ${message || ''}`);
 }

--- a/src/utils/observable.ts
+++ b/src/utils/observable.ts
@@ -1,0 +1,69 @@
+/**
+ * A wrapper around a value of type `T` that can be subscribed to whenever the
+ * underlying value changes.
+ */
+export class Observable<T> {
+  private _listeners: Set<(arg: T) => void> = new Set();
+  private _value: T;
+  /** Returns the current value. */
+  get value() {
+    return this._value;
+  }
+  /** Every change to the value triggers all the registered callbacks. */
+  set value(value: T) {
+    this._value = value;
+    this._listeners.forEach(fn => fn(value));
+  }
+
+  constructor(value: T) {
+    this._value = value;
+  }
+
+  /**
+   * Registers a listener function that's called whenever the underlying value
+   * changes.
+   * @returns a function that unregisters the listener when called.
+   */
+  public observe(fn: (arg: T) => void): () => void {
+    this._listeners.add(fn);
+
+    return () => this._listeners.delete(fn);
+  }
+}
+
+/**
+ * Capable of observing an `Observable<T>` type.
+ *
+ * Convenient when using a single observer that potentially binds multiple times
+ * to different observables, where it automatically unregisters from previous
+ * observables.
+ */
+// tslint:disable-next-line: max-classes-per-file
+export class Observer<T> {
+  private _observable?: Observable<T>;
+  private _stopObserving?: () => void;
+  /** Returns the current value of a bound observable, if there is one. */
+  get value() {
+    return this._observable && this._observable.value;
+  }
+  /**
+   * Binds to an observable value, along with the provided listener that's
+   * called whenever the underlying value changes.
+   */
+  public bind(observable: Observable<T>, handler: (arg: T) => void) {
+    this.stop();
+
+    this._observable = observable;
+    this._stopObserving = observable.observe(handler);
+  }
+  /** Unbinds from the observable, deregistering the previously bound callback. */
+  public stop() {
+    if (this._stopObserving) {
+      this._stopObserving();
+      delete this._stopObserving;
+    }
+    if (this._observable) {
+      delete this._observable;
+    }
+  }
+}


### PR DESCRIPTION
Fixes tracking of the active workspace (which is done based on the active text editor rather than last opened file) and also implements tracking of progress per workspace rather than globally. This means that the currently shown progress is for an active workspace rather than last reported one.

This touched some logic related to opening text editors vs changing focus and so in addition to cleaning it up a bit, this now doesn't automatically start RLS instances for each already opened document and added folder. This was done to make the extension lazier (similar to built-in JS/TS service in VSCode) and lighter on the CPU for use cases such as monorepo or short to middle sessions where not every project is opened and edited.