### PR TITLE
Add start and stop commands for RLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+* Add a Start/Stop the RLS command
+* Introduce a `rust-client.autoStartRls` (defaults to true) setting to control the auto-start
+behaviour when opening a relevant Rust project file
 * (!) Don't immediately start server instances for every already opened file
 * (!) Don't immediately start server instances for newly added workspace folders
 * Dynamically show progress only for the active client workspace

--- a/package.json
+++ b/package.json
@@ -94,6 +94,18 @@
                 "title": "Restart the RLS",
                 "description": "Sometimes, it's just best to try turning it off and on again",
                 "category": "Rust"
+            },
+            {
+                "command": "rls.start",
+                "title": "Start the RLS",
+                "description": "Start the RLS (when rust-client.autoStartRls is false or when manually stopped)",
+                "category": "Rust"
+            },
+            {
+                "command": "rls.stop",
+                "title": "Stop the RLS",
+                "description": "Stop the RLS for a workspace until manually started again",
+                "category": "Rust"
             }
         ],
         "taskDefinitions": [
@@ -186,6 +198,12 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Update the RLS whenever the extension starts up."
+                },
+                "rust-client.autoStartRls": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Start RLS automatically when opening a file or project.",
+                    "scope": "resource"
                 },
                 "rust-client.disableRustup": {
                     "type": "boolean",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -118,6 +118,13 @@ export class RLSConfiguration {
     return this.configuration.get<string>('rust-client.rlsPath');
   }
 
+  /**
+   * Whether RLS should be automaticallystarted when opening a relevant Rust project.
+   */
+  public get autoStartRls(): boolean {
+    return this.configuration.get<boolean>('rust-client.autoStartRls', true);
+  }
+
   // Added ignoreChannel for readChannel function. Otherwise we end in an infinite loop.
   public rustupConfig(ignoreChannel: boolean = false): RustupConfig {
     return {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,7 +160,7 @@ function clientWorkspaceForUri(
   if (!existing && options && options.startIfMissing) {
     const workspace = new ClientWorkspace(folder);
     workspaces.set(folder.uri.toString(), workspace);
-    workspace.auto_start();
+    workspace.autoStart();
   }
 
   return workspaces.get(folder.uri.toString());
@@ -188,10 +188,13 @@ class ClientWorkspace {
     this._progress = new Observable<{ message: string } | null>(null);
   }
 
-  public auto_start() {
-    if (this.config.autoStartRls) {
-      this.start();
-    }
+  /**
+   * Attempts to start a server instance, if not configured otherwise via
+   * applicable `rust-client.autoStartRls` setting.
+   * @returns whether the server has started.
+   */
+  public async autoStart() {
+    return this.config.autoStartRls && this.start().then(() => true);
   }
 
   public async start() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,7 +160,7 @@ function clientWorkspaceForUri(
   if (!existing && options && options.startIfMissing) {
     const workspace = new ClientWorkspace(folder);
     workspaces.set(folder.uri.toString(), workspace);
-    workspace.start();
+    workspace.auto_start();
   }
 
   return workspaces.get(folder.uri.toString());
@@ -186,6 +186,12 @@ class ClientWorkspace {
     this.folder = folder;
     this.disposables = [];
     this._progress = new Observable<{ message: string } | null>(null);
+  }
+
+  public auto_start() {
+    if (this.config.autoStartRls) {
+      this.start();
+    }
   }
 
   public async start() {
@@ -265,6 +271,7 @@ class ClientWorkspace {
   public async stop() {
     if (this.lc) {
       await this.lc.stop();
+      this.lc = null;
     }
 
     this.disposables.forEach(d => d.dispose());
@@ -465,6 +472,14 @@ function registerCommands(): Disposable[] {
     commands.registerCommand(
       'rls.run',
       (cmd: Execution) => activeWorkspace && activeWorkspace.runRlsCommand(cmd),
+    ),
+    commands.registerCommand(
+      'rls.start',
+      () => activeWorkspace && activeWorkspace.start(),
+    ),
+    commands.registerCommand(
+      'rls.stop',
+      () => activeWorkspace && activeWorkspace.stop(),
     ),
   ];
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,7 +100,7 @@ function onDidChangeActiveTextEditor(editor: TextEditor | undefined) {
   const { languageId, uri } = editor.document;
 
   const workspace = clientWorkspaceForUri(uri, {
-    startIfMissing: languageId === 'rust' || languageId === 'toml',
+    initializeIfMissing: languageId === 'rust' || languageId === 'toml',
   });
   if (!workspace) {
     return;
@@ -139,12 +139,12 @@ function whenChangingWorkspaceFolders(e: WorkspaceFoldersChangeEvent) {
 const workspaces: Map<string, ClientWorkspace> = new Map();
 
 /**
- * Fetches a `ClientWorkspace` for a given URI. If missing and `startIfMissing`
+ * Fetches a `ClientWorkspace` for a given URI. If missing and `initializeIfMissing`
  * option was provided, it is additionally initialized beforehand, if applicable.
  */
 function clientWorkspaceForUri(
   uri: Uri,
-  options?: { startIfMissing: boolean },
+  options?: { initializeIfMissing: boolean },
 ): ClientWorkspace | undefined {
   const rootFolder = workspace.getWorkspaceFolder(uri);
   if (!rootFolder) {
@@ -157,7 +157,7 @@ function clientWorkspaceForUri(
   }
 
   const existing = workspaces.get(folder.uri.toString());
-  if (!existing && options && options.startIfMissing) {
+  if (!existing && options && options.initializeIfMissing) {
     const workspace = new ClientWorkspace(folder);
     workspaces.set(folder.uri.toString(), workspace);
     workspace.autoStart();


### PR DESCRIPTION
Closes #682
Closes #340

This is rebased (yet again, sorry) #682 with a graphic symbol showing whether a server instance is stopped or ready and running for a given Rust project.