### PR TITLE
Use a regular heart character in RLS installation message

### DIFF
--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -75,7 +75,7 @@ export async function checkForRls(config: RustupConfig) {
   );
   if (clicked) {
     await installRlsComponents(config);
-    window.showInformationMessage('RLS successfully installed! Enjoy! 🎉');
+    window.showInformationMessage('RLS successfully installed! Enjoy! ❤️');
   } else {
     throw new Error();
   }


### PR DESCRIPTION
In hopes that this will be rendered correctly for everyone. This symbol
has been accepted as part of Unicode 1.1 in 1993 and so should be
universally supported by now.

It's worth noting that octicons do not work in `window.show*Message`, so
we can't use any fancy built-ins such as $(heart).

Fixes #618 