### PR TITLE
Handle rustup toolchain shorthands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Accept rustup toolchain shorthands in `rust-client.channel`, e.g. `stable-gnu` or `nightly-x86_64-msvc`
 * Remove deprecated `rust-client.useWsl` setting (use the official
 [Remote - WSL](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) extension instead)
 


### PR DESCRIPTION
This includes different ABIs, e.g. `stable-msvc` but also architecture such as `nightly-x86_64-gnu`.

@judemille thank you for your work and sorry it took so long! I hope you don't mind me adapting the changes, I did some more poking to see what rustup respects in terms of toolchain shorthands and wanted to support these cases as well.

Closes #642