### PR TITLE
Bump required VSCode version and use LSP 3.15

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        # Lock to the version shipped with VSCode 1.36+
-        node-version: ['10.10']
+        # Lock to the version shipped with VSCode 1.43+
+        node-version: ['12.8.1']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Use Node.js 12.8.1
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.8.1'
       - name: Build extension package
         run: |
           npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Bump required VSCode version to 1.43, use language server protocol (LSP) v3.15
+
 ### 0.7.5 - 2020-05-06
 
 * Remove redundant snippets and improve usability of select ones e.g. `if let`

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,15 +60,15 @@
             "dev": true
         },
         "@types/node": {
-            "version": "10.10.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.10.3.tgz",
-            "integrity": "sha512-dWk7F3b0m6uDLHero7tsnpAi9r2RGPQHGbb0/VCv7DPJRMFtk3RonY1/29vfJKnheRMBa7+uF+vunlg/mBGlxg==",
+            "version": "12.12.38",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.38.tgz",
+            "integrity": "sha512-75eLjX0pFuTcUXnnWmALMzzkYorjND0ezNEycaKesbUBg9eGZp4GHPuDmkRc4mQQvIpe29zrzATNRA6hkYqwmA==",
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.35.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.35.0.tgz",
-            "integrity": "sha512-Iyliuu8Hv4qy4TEaevQzChh9UsTEcuaKdcHXBbvJnoJSF5Td2yNENOrPK+vuOaXJJBhQZb4BNJKOxt6caaQR8A==",
+            "version": "1.44.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.44.0.tgz",
+            "integrity": "sha512-WJZtZlinE3meRdH+I7wTsIhpz/GLhqEQwmPGeh4s1irWLwMzCeTV8WZ+pgPTwrDXoafVUWwo1LiZ9HJVHFlJSQ==",
             "dev": true
         },
         "agent-base": {
@@ -1026,9 +1026,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "1.18.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-            "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+            "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
             "dev": true
         },
         "read": {
@@ -1264,9 +1264,9 @@
             }
         },
         "typescript": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-            "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
             "dev": true
         },
         "uc.micro": {
@@ -1322,31 +1322,39 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-            "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+            "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
         },
         "vscode-languageclient": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.4.2.tgz",
-            "integrity": "sha512-9TUzsg1UM6n1UEyPlWbDf7tK1wJAK7UGFRmGDN8sz4KmbbDiVRh6YicaB/5oRSVTpuV47PdJpYlOl3SJ0RiK1Q==",
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.1.3.tgz",
+            "integrity": "sha512-YciJxk08iU5LmWu7j5dUt9/1OLjokKET6rME3cI4BRpiF6HZlusm2ZwPt0MYJ0lV5y43sZsQHhyon2xBg4ZJVA==",
             "requires": {
-                "vscode-languageserver-protocol": "^3.10.3"
+                "semver": "^6.3.0",
+                "vscode-languageserver-protocol": "^3.15.3"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                }
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
-            "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
+            "version": "3.15.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
+            "integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
             "requires": {
-                "vscode-jsonrpc": "^4.0.0",
-                "vscode-languageserver-types": "3.14.0"
+                "vscode-jsonrpc": "^5.0.1",
+                "vscode-languageserver-types": "3.15.1"
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-            "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+            "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
         },
         "vscode-test": {
             "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.36.0"
+        "vscode": "^1.43.0"
     },
     "license": "(MIT OR Apache-2.0)",
     "repository": {
@@ -50,21 +50,21 @@
         "installDevExtension": "npm install && ./node_modules/.bin/vsce package -o ./out/rls-vscode-dev.vsix && code --install-extension ./out/rls-vscode-dev.vsix"
     },
     "dependencies": {
-        "vscode-languageclient": "^4.3.0"
+        "vscode-languageclient": "^6.0.0"
     },
     "devDependencies": {
         "@types/chai": "^4.2.11",
         "@types/glob": "^7.1.1",
         "@types/mocha": "^5.2.6",
-        "@types/node": "^10.10",
-        "@types/vscode": "^1.31.0",
+        "@types/node": "^12.8.1",
+        "@types/vscode": "^1.43.0",
         "chai": "^4.2.0",
         "glob": "^7.1.4",
         "mocha": "^6.2.3",
-        "prettier": "^1.16.4",
+        "prettier": "^1.19.1",
         "tslint": "^5.14.0",
         "tslint-config-prettier": "^1.18.0",
-        "typescript": "^3.0.0",
+        "typescript": "^3.8.3",
         "vsce": "^1.63.0",
         "vscode-test": "^1.3.0"
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -433,7 +433,7 @@ export class ClientWorkspace {
     if (this.config.logToFile) {
       const logPath = path.join(this.folder.uri.fsPath, `rls${Date.now()}.log`);
       const logStream = fs.createWriteStream(logPath, { flags: 'w+' });
-      childProcess.stderr.pipe(logStream);
+      childProcess.stderr?.pipe(logStream);
     }
 
     return childProcess;

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -85,7 +85,11 @@ async function fetchBriefTasks(): Promise<
   return tasks.map(task => ({
     subcommand: task.definition.subcommand,
     group: task.group,
-    cwd: task.execution && task.execution.options && task.execution.options.cwd,
+    cwd:
+      ((task.execution instanceof vscode.ProcessExecution ||
+        task.execution instanceof vscode.ShellExecution) &&
+        task.execution?.options?.cwd) ||
+      undefined,
   }));
 }
 


### PR DESCRIPTION
The main reason for this bump is to pull in `vscode-languageclient@^6.0`, which implements LSP 3.15, most notably new progress API and other goodies such as diagnostics with deprecated tag. 

Since rust-analyzer pushes the envelope wrt LSP and uses proposed/cutting edge features, we should land this before offering the switch not to regress anything major when compared to the rust-analyzer VSCode extension.

Refs: #780 