### PR TITLE
Add String::from() snippet

### DIFF
--- a/snippets/rust.json
+++ b/snippets/rust.json
@@ -71,4 +71,11 @@
         ],
         "description": "#[test]"
     }
+	"String::from()": {
+		"prefix": "strfrom",
+		"body": [
+			"String::from(\"$1\")$0"
+		],
+		"description": "String::from(\"…\")"
+	}
 }


### PR DESCRIPTION
This snippet listens on `strfrom` and writes `String::from("")` (with the cursor between the two quotation marks).

I think this is a really helpful snippet, because I find myself often typing out `String::from()`. 